### PR TITLE
clippy forbid as conversions

### DIFF
--- a/labrador/src/lib.rs
+++ b/labrador/src/lib.rs
@@ -3,6 +3,7 @@
 // Main Introduction
 
 #![forbid(unsafe_code)]
+#![deny(clippy::as_conversions)]
 #![doc = include_str!("../../doc/mainpage-doc.md")]
 // Arithmetic Circuit Translation
 #![doc = include_str!("../../doc/arithmetic_circuit_translation.md")]


### PR DESCRIPTION
- [ ] forbid potentially lossy `as` conversions (if some cases require special treatment, we will tune more [granularly](https://rust-lang.github.io/rust-clippy/stable/index.html#as_conversions))