### PR TITLE
fix(ci): prevent cargo-deny installation conflicts in dependency audit

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -37,5 +37,5 @@ jobs:
 
       - name: Run audit-check action
         run: |
-          cargo install cargo-deny
+          which cargo-deny || cargo install cargo-deny
           cargo deny check


### PR DESCRIPTION
Modify GitHub Actions workflow to check for existing cargo-deny installation before attempting to install. This resolves CI failures caused by version conflicts when the binary already exists in the environment. The conditional install ensures we only add the dependency when missing while maintaining required security checks.