### PR TITLE
Update pre-push with skip-slow-tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,7 +26,7 @@ cargo clippy --all-targets --all-features -- -D warnings || {
 }
 
 # Tests
-cargo test --workspace --verbose || {
+cargo test --workspace --verbose --features skip-slow-tests || {
     echo "❌ Test failures detected"
     exit 5
 }


### PR DESCRIPTION
The `--features skip-slow-tests` flag is added in `cargo test` to skip slow tests locally, but those tests should still run in CI (this is related to issue "Conditional test run")

closes #35 