### PR TITLE
slow tests; zq ord trait

### DIFF
--- a/labrador/src/jl.rs
+++ b/labrador/src/jl.rs
@@ -196,7 +196,7 @@ mod tests {
         let mut matrix = ProjectionMatrix::new(n);
         let mut projection = ProjectionVector::new(&matrix, &polynomials);
         let mut norm_sum = projection.norm_squared();
-        let norm_value = Zq::new(128) * RqVector::compute_norm_squared(&polynomials);
+        let norm_value = (Zq::new(128) * RqVector::compute_norm_squared(&polynomials)).to_u128();
         // Run the test multiple times to simulate the probability
         for _ in 0..trials {
             matrix = ProjectionMatrix::new(n);
@@ -206,10 +206,10 @@ mod tests {
 
         // Calculate the observed probability
         let average = norm_sum.to_u128() / trials;
-        let difference = if norm_value.to_u128() <= average {
-            average - norm_value.to_u128()
+        let difference = if norm_value <= average {
+            average - norm_value
         } else {
-            norm_value.to_u128() - average
+            norm_value - average
         };
 
         // we choose a small tolerance value for possible statistical error

--- a/labrador/src/main.rs
+++ b/labrador/src/main.rs
@@ -66,6 +66,6 @@ fn main() {
     // Calculate projection
     let projection = ProjectionVector::new(&matrix, &polynomials);
     // Within bounds with probability 1/2
-    let beta = RqVector::compute_norm_squared(&polynomials);
+    let beta = polynomials.compute_norm_squared();
     println!("{}", verify_upper_bound(projection, beta));
 }

--- a/labrador/src/rq_matrix.rs
+++ b/labrador/src/rq_matrix.rs
@@ -59,6 +59,7 @@ mod tests {
     use crate::{rq::Rq, zq::Zq};
 
     #[test]
+    #[cfg(not(feature = "skip-slow-tests"))]
     fn rqmatrix_fits_stack() {
         let mut rng = rand::rng();
         let _: RqMatrix<256, { 1 << 10 }, 64> = RqMatrix::random(&mut rng);

--- a/labrador/src/rq_vector.rs
+++ b/labrador/src/rq_vector.rs
@@ -153,15 +153,15 @@ mod tests {
         ]
         .into();
         let result = Zq::new(53);
-        assert!(RqVector::compute_norm_squared(&poly).to_u128() == result.to_u128());
+        assert!(poly.compute_norm_squared() == result);
 
         let poly2: RqVector<1, 4> =
             vec![vec![Zq::new(5), Zq::ONE, Zq::MAX, Zq::ZERO].into()].into();
         let result2 = Zq::new(27);
-        assert!(RqVector::compute_norm_squared(&poly2).to_u128() == result2.to_u128());
+        assert!(poly2.compute_norm_squared() == result2);
 
         let poly_zero: RqVector<4, 4> = RqVector::zero();
         let result_zero = Zq::ZERO;
-        assert!(RqVector::compute_norm_squared(&poly_zero).to_u128() == result_zero.to_u128());
+        assert!(poly_zero.compute_norm_squared() == result_zero);
     }
 }


### PR DESCRIPTION
Sorry @mattsuffern I've misled you a little with conditional compilation - we need `#[cfg(not(feature = "skip-slow-tests"))]` so by default that feature is not turned on.

