### PR TITLE
Fix Ajtai commitment test to use random matrix instead of random_small

### DIFF
--- a/labrador/src/ajtai_commitment.rs
+++ b/labrador/src/ajtai_commitment.rs
@@ -221,7 +221,7 @@ mod tests {
 
         pub fn setup_scheme() -> TestAjtai {
             let mut rng = rand::rng();
-            let matrix_a = RqMatrix::random_small(&mut rng);
+            let matrix_a = RqMatrix::random(&mut rng);
             TestAjtai::new(AjtaiParameters::new(Zq::ONE, Zq::ONE).unwrap(), matrix_a).unwrap()
         }
     }


### PR DESCRIPTION
This PR updates the Ajtai commitment test to use a random matrix instead of a random_small matrix, aligning with the implementation discussed in issue #21. The change ensures that tests correctly reflect the intended usage pattern where users can provide their own randomly generated matrix.

Closes https://github.com/nethermindeth/condor-rs/issues/31

## How to reproduce the problem

The Ajtai commitment test was using `RqMatrix::random_small()` for matrix generation, which doesn't match the intended usage pattern. In Ajtai commitments (t_i = A*s_i), there is no norm check needed for matrix A, while the norm check for s_i (||s_i|| <= β) remains in place.

## How I tested the fix

Verified that the test continues to pass with the updated matrix generation method, confirming that the Ajtai commitment scheme works correctly with randomly generated matrices.

## How the reviewer should test the fix

1. Run the Ajtai commitment tests to ensure they pass with the updated matrix generation
2. Verify that this change aligns with the implementation discussed in issue #21
3. Confirm that the commitment scheme still functions correctly with the random matrix

## Other useful info

This change is minimal but important for ensuring that our tests accurately reflect the intended usage of the Ajtai commitment scheme. The key insight is that in Ajtai commitments, while we need to check the norm of s_i (||s_i|| <= β), there is no such requirement for matrix A, which can be fully random.