### PR TITLE
Implement Hierarchical Commitment Scheme for LaBRADOR Protocol

### DIFF
--- a/labrador/doc/hierarchical_commitment.md
+++ b/labrador/doc/hierarchical_commitment.md
@@ -1,0 +1,45 @@
+# Hierarchical Commitment Structure
+
+A key optimization in the LaBRADOR protocol is the use of hierarchical commitments - a two-layer structure with inner and outer commitments.
+
+## Inner and Outer Commitments
+
+The hierarchical commitment structure consists of:
+
+1. **Inner Commitments**: First-level commitments to witness vectors
+2. **Outer Commitments**: Second-level commitments that summarize multiple inner commitments
+
+This two-layer structure is crucial for reducing proof size by allowing the prover to move material from the current proof iteration to the next iteration, where it will be further compressed.
+
+## Decomposition Process
+
+When creating a hierarchical commitment:
+
+1. The prover first commits to each witness vector using individual Ajtai commitments, creating the inner commitments
+2. These inner commitments are then decomposed into a base-B representation to reduce coefficient size
+3. The decomposed parts are concatenated into a single vector
+4. This vector is then committed to using another Ajtai commitment, creating the outer commitment
+
+The decomposition uses centered representatives modulo the base to minimize the magnitude of coefficients, ensuring compactness.
+
+## Verification Process
+
+To verify a hierarchical commitment:
+
+1. The verifier checks each inner commitment against its opening information
+2. The verifier then decomposes the inner commitments using the same process
+3. The decomposed parts are concatenated and committed to using the outer commitment scheme
+4. The resulting commitment is compared against the provided outer commitment
+5. The outer commitment's opening information is also verified
+
+## Benefits of Hierarchical Commitments
+
+The hierarchical structure provides several advantages:
+
+1. **Reduced Communication Complexity**: By summarizing multiple inner commitments into a single outer commitment, the total size of the proof is reduced
+2. **Efficient Verification**: The verification process can be performed efficiently even with the two-layer structure
+3. **Flexibility**: The decomposition parameters can be adjusted to optimize for specific use cases
+
+## Integration with LaBRADOR Protocol
+
+In the context of the LaBRADOR protocol, hierarchical commitments allow moving material from π(i+1) to s(i+1), which is then shrunk in subsequent iterations, resulting in a more compact overall proof size.

--- a/labrador/src/hierarchical_commitment.rs
+++ b/labrador/src/hierarchical_commitment.rs
@@ -1,0 +1,357 @@
+use crate::{
+    ajtai_commitment::{
+        AjtaiCommitment, AjtaiParameters, CommitError, Opening, ParameterError, VerificationError,
+    },
+    rq::Rq,
+    rq_matrix::RqMatrix,
+    rq_vector::RqVector,
+    zq::Zq,
+};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum HierarchicalError {
+    #[error("parameter error: {0}")]
+    ParameterError(#[from] ParameterError),
+    #[error("commit error: {0}")]
+    CommitError(#[from] CommitError),
+    #[error("verification error: {0}")]
+    VerificationError(#[from] VerificationError),
+    #[error("invalid decomposition base: {0}")]
+    InvalidBase(Zq),
+    #[error("invalid number of parts: {0}")]
+    InvalidPartCount(usize),
+    #[error("empty witness batch")]
+    EmptyWitnessBatch,
+}
+
+/// Parameters for polynomial decomposition in hierarchical commitments
+/// The base parameter controls how coefficients are decomposed
+/// The num_parts parameter determines how many parts each coefficient is split into
+#[derive(Debug, Clone)]
+pub struct DecompositionParameters {
+    base: Zq,
+    num_parts: usize,
+}
+
+impl DecompositionParameters {
+    /// Creates new decomposition parameters with validation
+    /// - base must be greater than 1 for meaningful decomposition
+    /// - num_parts must be positive to ensure decomposition occurs
+    pub fn new(base: Zq, num_parts: usize) -> Result<Self, HierarchicalError> {
+        if base <= Zq::ONE {
+            return Err(HierarchicalError::InvalidBase(base));
+        }
+        if num_parts == 0 {
+            return Err(HierarchicalError::InvalidPartCount(num_parts));
+        }
+
+        Ok(Self { base, num_parts })
+    }
+
+    /// Returns the decomposition base
+    pub fn base(&self) -> Zq {
+        self.base
+    }
+
+    /// Returns the number of decomposition parts
+    pub fn num_parts(&self) -> usize {
+        self.num_parts
+    }
+}
+
+/// Proof structure for hierarchical commitments
+/// Contains all information needed to verify the commitment structure:
+/// - Outer commitment and its opening
+/// - All inner commitments and their openings
+/// - The flattened decomposed parts for consistency checking
+#[derive(Debug, Clone)]
+pub struct HierarchicalProof<const M: usize, const N: usize, const D: usize> {
+    /// Outer commitment that summarizes inner commitments
+    pub outer_commitment: RqVector<M, D>,
+    /// Opening information for the outer commitment
+    pub outer_opening: Opening<N, D>,
+    /// Inner commitments for individual witnesses
+    pub inner_commitments: Vec<RqVector<M, D>>,
+    /// Opening information for each inner commitment
+    pub inner_openings: Vec<Opening<N, D>>,
+    /// Flattened parts of all inner commitments
+    pub flattened_parts: Vec<Rq<D>>,
+}
+
+/// Two-layer commitment structure with inner and outer commitments
+/// - M: Size of commitment output
+/// - N: Size of witness vector
+/// - D: Degree of the polynomials
+#[derive(Debug)]
+pub struct HierarchicalCommitment<const M: usize, const N: usize, const D: usize> {
+    // Inner commitment scheme for individual witnesses
+    inner_scheme: AjtaiCommitment<M, N, D>,
+    // Outer commitment scheme for summarizing inner commitments
+    outer_scheme: AjtaiCommitment<M, N, D>,
+    // Parameters for decomposing polynomials
+    decomp_params: DecompositionParameters,
+}
+
+impl<const M: usize, const N: usize, const D: usize> HierarchicalCommitment<M, N, D> {
+    /// Creates a new hierarchical commitment scheme with separate matrices for inner and outer commitments
+    /// Both schemes use the same AjtaiParameters for consistent security
+    pub fn new(
+        params: AjtaiParameters,
+        inner_matrix: RqMatrix<M, N, D>,
+        outer_matrix: RqMatrix<M, N, D>,
+        decomp_params: DecompositionParameters,
+    ) -> Result<Self, HierarchicalError> {
+        let inner_scheme = AjtaiCommitment::new(params.clone(), inner_matrix)?;
+        let outer_scheme = AjtaiCommitment::new(params, outer_matrix)?;
+
+        Ok(Self {
+            inner_scheme,
+            outer_scheme,
+            decomp_params,
+        })
+    }
+
+    fn decompose_polynomial(&self, poly: &Rq<D>) -> Vec<Rq<D>> {
+        poly.decompose(self.decomp_params.base(), self.decomp_params.num_parts())
+    }
+
+    /// Helper method to decompose all inner commitments into a single flattened vector
+    /// This collects all the decomposed parts from all polynomials in all commitments
+    fn decompose_all_commitments(&self, commitments: &[RqVector<M, D>]) -> Vec<Rq<D>> {
+        let capacity = commitments.len() * M * self.decomp_params.num_parts();
+        let mut all_parts = Vec::with_capacity(capacity);
+        for commitment in commitments {
+            for poly in commitment.iter() {
+                let decomposed_parts = self.decompose_polynomial(poly);
+                all_parts.extend(decomposed_parts);
+            }
+        }
+        all_parts
+    }
+
+    /// Creates a valid outer witness from decomposed parts
+    /// This involves:
+    /// 1. Selecting N polynomials from the decomposed parts
+    /// 2. Ensuring all coefficients are within the witness bound
+    /// 3. Using centered representatives to minimize coefficient size
+    fn create_outer_witness(&self, parts: &[Rq<D>]) -> RqVector<N, D> {
+        let witness_bound = self.outer_scheme.witness_bound();
+        let mut combined_coeffs = Vec::with_capacity(N);
+
+        // Handle the case where we have more or fewer parts than N
+        if parts.len() >= N {
+            // Take the first N parts
+            for part in parts.iter().take(N) {
+                combined_coeffs.push(part.clone());
+            }
+        } else {
+            // Use all available parts and pad with zeros
+            for part in parts {
+                combined_coeffs.push(part.clone());
+            }
+
+            // Pad with zeros to reach size N
+            while combined_coeffs.len() < N {
+                combined_coeffs.push(Rq::zero());
+            }
+        }
+
+        // Apply witness bounds to ensure all coefficients are valid
+        let mut bounded_coeffs = Vec::with_capacity(N);
+        for poly in &combined_coeffs {
+            // Create a new polynomial with bounded coefficients
+            let mut bounded_coeffs_array = [Zq::ZERO; D];
+            for (i, coeff) in poly.get_coefficients().iter().enumerate() {
+                bounded_coeffs_array[i] = coeff.centered_mod(witness_bound);
+            }
+            bounded_coeffs.push(Rq::new(bounded_coeffs_array));
+        }
+
+        RqVector::from(bounded_coeffs)
+    }
+
+    /// Commits to a batch of witnesses using the hierarchical structure
+    /// This creates both inner commitments for each witness and an outer commitment
+    /// that summarizes them all, providing a more compact representation
+    pub fn commit_batch(
+        &self,
+        witnesses: &[RqVector<N, D>],
+    ) -> Result<HierarchicalProof<M, N, D>, HierarchicalError> {
+        if witnesses.is_empty() {
+            return Err(HierarchicalError::EmptyWitnessBatch);
+        }
+
+        // Generate inner commitments and openings
+        let mut inner_commitments = Vec::with_capacity(witnesses.len());
+        let mut inner_openings = Vec::with_capacity(witnesses.len());
+
+        for witness in witnesses {
+            let (commitment, opening) = self.inner_scheme.commit(witness.clone())?;
+            inner_commitments.push(commitment);
+            inner_openings.push(opening);
+        }
+
+        // Decompose inner commitments and create a flattened vector for the outer commitment
+        let flattened_parts = self.decompose_all_commitments(&inner_commitments);
+
+        // Create a valid outer witness
+        let outer_witness = self.create_outer_witness(&flattened_parts);
+
+        // Create outer commitment
+        let (outer_commitment, outer_opening) = self.outer_scheme.commit(outer_witness)?;
+
+        Ok(HierarchicalProof {
+            outer_commitment,
+            outer_opening,
+            inner_commitments,
+            inner_openings,
+            flattened_parts,
+        })
+    }
+
+    /// Verifies a hierarchical proof
+    /// This ensures:
+    /// 1. All inner commitments match their openings
+    /// 2. The decomposed parts match what's stored in the proof
+    /// 3. The outer commitment correctly summarizes the inner commitments
+    /// 4. The outer commitment matches its opening
+    pub fn verify(&self, proof: &HierarchicalProof<M, N, D>) -> Result<(), HierarchicalError> {
+        // Verify each inner commitment
+        for (commitment, opening) in proof
+            .inner_commitments
+            .iter()
+            .zip(proof.inner_openings.iter())
+        {
+            self.inner_scheme.verify(commitment, opening)?;
+        }
+
+        // Verify outer commitment consistency
+        // First, decompose inner commitments
+        let flattened_parts = self.decompose_all_commitments(&proof.inner_commitments);
+
+        // Compare with stored flattened parts
+        if flattened_parts != proof.flattened_parts {
+            return Err(HierarchicalError::VerificationError(
+                VerificationError::CommitmentMismatch,
+            ));
+        }
+
+        // Create the same outer witness
+        let outer_witness = self.create_outer_witness(&flattened_parts);
+
+        // Create expected outer commitment
+        let (expected_outer, _) = self.outer_scheme.commit(outer_witness)?;
+
+        // Check if outer commitment matches expected
+        if proof.outer_commitment != expected_outer {
+            return Err(HierarchicalError::VerificationError(
+                VerificationError::CommitmentMismatch,
+            ));
+        }
+
+        // Verify outer opening
+        self.outer_scheme
+            .verify(&proof.outer_commitment, &proof.outer_opening)?;
+
+        Ok(())
+    }
+
+    /// Returns a reference to the inner commitment scheme
+    pub fn inner_scheme(&self) -> &AjtaiCommitment<M, N, D> {
+        &self.inner_scheme
+    }
+
+    /// Returns a reference to the outer commitment scheme
+    pub fn outer_scheme(&self) -> &AjtaiCommitment<M, N, D> {
+        &self.outer_scheme
+    }
+
+    /// Returns a reference to the decomposition parameters
+    pub fn decomp_params(&self) -> &DecompositionParameters {
+        &self.decomp_params
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rng;
+
+    const TEST_M: usize = 8;
+    const TEST_N: usize = 8;
+    const TEST_D: usize = 4;
+
+    // Test helpers
+    fn create_test_scheme() -> HierarchicalCommitment<TEST_M, TEST_N, TEST_D> {
+        let beta = Zq::ONE;
+        let witness_bound = Zq::ONE;
+        let params = AjtaiParameters::new(beta, witness_bound).unwrap();
+
+        let mut rng = rng();
+        let inner_matrix = RqMatrix::<TEST_M, TEST_N, TEST_D>::random(&mut rng);
+        let outer_matrix = RqMatrix::<TEST_M, TEST_N, TEST_D>::random(&mut rng);
+
+        let decomp_params = DecompositionParameters::new(Zq::new(8), 2).unwrap();
+
+        HierarchicalCommitment::new(params, inner_matrix, outer_matrix, decomp_params).unwrap()
+    }
+
+    fn create_random_witnesses(count: usize) -> Vec<RqVector<TEST_N, TEST_D>> {
+        let mut rng = rng();
+        (0..count)
+            .map(|_| RqVector::random_ternary(&mut rng))
+            .collect()
+    }
+
+    #[test]
+    fn test_decomposition_parameters() {
+        assert!(DecompositionParameters::new(Zq::ZERO, 2).is_err());
+        assert!(DecompositionParameters::new(Zq::TWO, 0).is_err());
+        let params = DecompositionParameters::new(Zq::new(8), 3).unwrap();
+        assert_eq!(params.base(), Zq::new(8));
+        assert_eq!(params.num_parts(), 3);
+    }
+
+    #[test]
+    fn test_hierarchical_creation() {
+        let _ = create_test_scheme();
+    }
+
+    #[test]
+    fn test_commit_and_verify() {
+        let scheme = create_test_scheme();
+        let witnesses = create_random_witnesses(3);
+
+        let proof = scheme.commit_batch(&witnesses).unwrap();
+        assert!(scheme.verify(&proof).is_ok());
+    }
+
+    #[test]
+    fn test_tampered_inner_commitment() {
+        let scheme = create_test_scheme();
+        let witnesses = create_random_witnesses(3);
+
+        let mut proof = scheme.commit_batch(&witnesses).unwrap();
+
+        // Tamper with an inner commitment
+        let mut rng = rng();
+        proof.inner_commitments[0] = RqVector::random(&mut rng);
+
+        assert!(scheme.verify(&proof).is_err());
+    }
+
+    #[test]
+    fn test_tampered_outer_commitment() {
+        let scheme = create_test_scheme();
+        let witnesses = create_random_witnesses(3);
+
+        let mut proof = scheme.commit_batch(&witnesses).unwrap();
+
+        // Tamper with the outer commitment
+        let mut rng = rng();
+        proof.outer_commitment = RqVector::random(&mut rng);
+
+        assert!(scheme.verify(&proof).is_err());
+    }
+}

--- a/labrador/src/lib.rs
+++ b/labrador/src/lib.rs
@@ -8,6 +8,8 @@
 #![doc = include_str!("../doc/arithmetic_circuit_translation.md")]
 // Ajtai Commitment
 #![doc = include_str!("../doc/ajtai_commitment.md")]
+// Hierarchical Commitment
+#![doc = include_str!("../doc/hierarchical_commitment.md")]
 // Projections
 #![doc = include_str!("../doc/projections.md")]
 // Aggregation
@@ -26,3 +28,5 @@ pub mod rq_matrix;
 pub mod rq_vector;
 
 pub mod jl;
+
+pub mod hierarchical_commitment;

--- a/labrador/src/rq.rs
+++ b/labrador/src/rq.rs
@@ -156,6 +156,42 @@ impl<const D: usize> Rq<D> {
         Rq::new(coeffs)
     }
 
+    /// Decomposes a polynomial into base-B representation:
+    /// p = p⁽⁰⁾ + p⁽¹⁾·B + p⁽²⁾·B² + ... + p⁽ᵗ⁻¹⁾·B^(t-1)
+    /// Where each p⁽ⁱ⁾ has small coefficients, using centered representatives
+    pub fn decompose(&self, base: Zq, num_parts: usize) -> Vec<Self> {
+        let mut parts = Vec::with_capacity(num_parts);
+        let mut current = self.clone();
+
+        for i in 0..num_parts {
+            if i == num_parts - 1 {
+                parts.push(current.clone());
+            } else {
+                // Extract low part (mod base, centered around 0)
+                let mut low_coeffs = [Zq::ZERO; D];
+
+                for (j, coeff) in current.get_coefficients().iter().enumerate() {
+                    low_coeffs[j] = coeff.centered_mod(base);
+                }
+
+                let low_part = Self::new(low_coeffs);
+                parts.push(low_part.clone());
+
+                // Update current
+                current -= low_part;
+
+                // Scale by base
+                let mut scaled_coeffs = [Zq::ZERO; D];
+                for (j, coeff) in current.get_coefficients().iter().enumerate() {
+                    scaled_coeffs[j] = coeff.scale_by(base);
+                }
+                current = Self::new(scaled_coeffs);
+            }
+        }
+
+        parts
+    }
+
     /// Encode message into polynomial with small coefficients.
     ///
     /// # Arguments
@@ -506,5 +542,293 @@ mod tests {
         let poly_zero: Rq<4> = vec![Zq::ZERO, Zq::ZERO, Zq::ZERO, Zq::ZERO].into();
         let vec_zero = vec![Zq::ZERO, Zq::ZERO, Zq::ZERO, Zq::ZERO];
         assert!(poly_zero.get_coefficients().to_vec() == vec_zero);
+    }
+
+    #[test]
+    fn test_base2_decomposition() {
+        // Test case 1: Base 2 decomposition
+        let poly: Rq<4> = vec![Zq::new(5), Zq::new(3), Zq::new(7), Zq::new(1)].into();
+        let parts = poly.decompose(Zq::TWO, 2);
+
+        // Part 0: remainders mod 2 (no centering needed for base 2)
+        assert_eq!(
+            parts[0].coeffs,
+            [
+                Zq::ONE, // 5 mod 2 = 1
+                Zq::ONE, // 3 mod 2 = 1
+                Zq::ONE, // 7 mod 2 = 1
+                Zq::ONE, // 1 mod 2 = 1
+            ]
+        );
+
+        // Part 1: quotients after division by 2
+        assert_eq!(
+            parts[1].coeffs,
+            [
+                Zq::new(2), // 5 div 2 = 2
+                Zq::ONE,    // 3 div 2 = 1
+                Zq::new(3), // 7 div 2 = 3
+                Zq::ZERO,   // 1 div 2 = 0
+            ]
+        );
+
+        // Verify Base 2 reconstruction coefficient by coefficient
+        for i in 0..4 {
+            let expected = poly.coeffs[i];
+            let actual = parts[0].coeffs[i] + parts[1].coeffs[i] * Zq::TWO;
+            assert_eq!(actual, expected, "Base 2: Coefficient {} mismatch", i);
+        }
+    }
+
+    #[test]
+    fn test_base3_decomposition() {
+        // Test case: Base 3 decomposition with centering
+        let specific_poly: Rq<4> = vec![Zq::new(8), Zq::new(11), Zq::new(4), Zq::new(15)].into();
+        let parts = specific_poly.decompose(Zq::new(3), 2);
+
+        // Part 0: centered remainders mod 3
+        assert_eq!(
+            parts[0].coeffs,
+            [
+                Zq::MAX,  // 8 mod 3 = 2 -> -1 (centered)
+                Zq::MAX,  // 11 mod 3 = 2 -> -1 (centered)
+                Zq::ONE,  // 4 mod 3 = 1 -> 1 (centered)
+                Zq::ZERO, // 15 mod 3 = 0 -> 0 (centered)
+            ]
+        );
+
+        // Part 1: quotients
+        assert_eq!(
+            parts[1].coeffs,
+            [
+                Zq::new(3), // (8 + 1) div 3 = 3
+                Zq::new(4), // (11 + 1) div 3 = 4
+                Zq::ONE,    // 4 div 3 = 1
+                Zq::new(5), // 15 div 3 = 5
+            ]
+        );
+
+        // Verify Base 3 reconstruction coefficient by coefficient
+        for i in 0..4 {
+            let expected = specific_poly.coeffs[i];
+            let p0 = parts[0].coeffs[i];
+            let p1 = parts[1].coeffs[i];
+            let actual = p0 + p1 * Zq::new(3);
+            assert_eq!(actual, expected, "Base 3: Coefficient {} mismatch", i);
+        }
+    }
+
+    #[test]
+    fn test_decomposition_edge_cases() {
+        // Test zero polynomial
+        let zero_poly: Rq<4> = vec![Zq::ZERO; 4].into();
+        let parts = zero_poly.decompose(Zq::TWO, 2);
+        assert!(
+            parts.iter().all(|p| p.is_zero()),
+            "Zero polynomial decomposition failed"
+        );
+
+        // Test single part decomposition
+        let simple_poly: Rq<4> = vec![Zq::ONE, Zq::new(2), Zq::new(3), Zq::new(4)].into();
+        let parts = simple_poly.decompose(Zq::TWO, 1);
+        assert_eq!(parts.len(), 1, "Single part decomposition length incorrect");
+        assert_eq!(
+            parts[0], simple_poly,
+            "Single part decomposition value incorrect"
+        );
+    }
+
+    #[test]
+    fn test_large_base_decomposition() {
+        // Test decomposition with larger bases (8 and 16)
+        let poly: Rq<4> = vec![Zq::new(120), Zq::new(33), Zq::new(255), Zq::new(19)].into();
+
+        // Base 8 decomposition
+        let parts_base8 = poly.decompose(Zq::new(8), 2);
+
+        // Part 0: centered remainders mod 8
+        assert_eq!(
+            parts_base8[0].coeffs,
+            [
+                Zq::ZERO,   // 120 mod 8 = 0 -> 0 (centered)
+                Zq::ONE,    // 33 mod 8 = 1 -> 1 (centered)
+                Zq::MAX,    // 255 mod 8 = 7 -> -1 (centered)
+                Zq::new(3), // 19 mod 8 = 3 -> 3 (centered)
+            ]
+        );
+
+        // Part 1: quotients
+        assert_eq!(
+            parts_base8[1].coeffs,
+            [
+                Zq::new(15), // 120 div 8 = 15
+                Zq::new(4),  // 33 div 8 = 4
+                Zq::new(32), // (255 + 1) div 8 = 32
+                Zq::new(2),  // 19 div 8 = 2
+            ]
+        );
+
+        // Verify reconstruction coefficient by coefficient
+        for i in 0..4 {
+            let expected = poly.coeffs[i];
+            let p0 = parts_base8[0].coeffs[i];
+            let p1 = parts_base8[1].coeffs[i];
+            let actual = p0 + p1 * Zq::new(8);
+            assert_eq!(actual, expected, "Base 8: Coefficient {} mismatch", i);
+        }
+
+        // Base 16 decomposition
+        let parts_base16 = poly.decompose(Zq::new(16), 2);
+
+        // Verify reconstruction for base 16
+        for i in 0..4 {
+            let expected = poly.coeffs[i];
+            let p0 = parts_base16[0].coeffs[i];
+            let p1 = parts_base16[1].coeffs[i];
+            let actual = p0 + p1 * Zq::new(16);
+            assert_eq!(actual, expected, "Base 16: Coefficient {} mismatch", i);
+        }
+    }
+
+    #[test]
+    fn test_multi_part_decomposition() {
+        // Test with more than 2 parts
+        let poly: Rq<4> = vec![Zq::new(123), Zq::new(456), Zq::new(789), Zq::new(101112)].into();
+
+        // Decompose into 3 parts with base 4
+        let parts = poly.decompose(Zq::new(4), 3);
+        assert_eq!(parts.len(), 3, "Should have 3 parts");
+
+        // Test reconstruction with all 3 parts
+        let reconstructed = parts[0].clone()
+            + parts[1].clone().scalar_mul(Zq::new(4))
+            + parts[2].clone().scalar_mul(Zq::new(16)); // 4²
+
+        // Verify reconstruction coefficient by coefficient
+        for i in 0..4 {
+            assert_eq!(
+                reconstructed.coeffs[i], poly.coeffs[i],
+                "3-part base 4: Coefficient {} mismatch",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_centering_properties() {
+        // Test that centering works correctly for various values
+        // Using base 5 which has half_base = 2
+        let values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let poly: Rq<11> = values
+            .iter()
+            .map(|&v| Zq::new(v))
+            .collect::<Vec<Zq>>()
+            .into();
+
+        let parts = poly.decompose(Zq::new(5), 2);
+
+        // Expected centered values for each coefficient:
+        // 0 mod 5 = 0 -> 0
+        // 1 mod 5 = 1 -> 1
+        // 2 mod 5 = 2 -> 2 (at threshold)
+        // 3 mod 5 = 3 -> -2 (centered)
+        // 4 mod 5 = 4 -> -1 (centered)
+        // 5 mod 5 = 0 -> 0
+        // ... and so on
+        let expected_centered = [
+            Zq::ZERO,    // 0 centered
+            Zq::ONE,     // 1 centered
+            Zq::new(2),  // 2 centered (at threshold)
+            -Zq::new(2), // 3 centered to -2
+            -Zq::ONE,    // 4 centered to -1
+            Zq::ZERO,    // 5 centered
+            Zq::ONE,     // 6 centered
+            Zq::new(2),  // 7 centered
+            -Zq::new(2), // 8 centered to -2
+            -Zq::ONE,    // 9 centered to -1
+            Zq::ZERO,    // 10 centered
+        ];
+
+        for (i, &expected) in expected_centered.iter().enumerate() {
+            assert_eq!(
+                parts[0].coeffs[i], expected,
+                "Base 5 centering: Coefficient {} incorrectly centered",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_extreme_values() {
+        // Test with values near the extremes of the Zq range
+        let poly: Rq<3> = vec![Zq::ZERO, Zq::MAX, Zq::MAX - Zq::ONE].into();
+
+        // Decompose with base 3
+        let parts = poly.decompose(Zq::new(3), 2);
+
+        // Verify reconstruction
+        let reconstructed = parts[0].clone() + parts[1].clone().scalar_mul(Zq::new(3));
+
+        for i in 0..3 {
+            assert_eq!(
+                reconstructed.coeffs[i], poly.coeffs[i],
+                "Extreme values: Coefficient {} mismatch",
+                i
+            );
+        }
+
+        // Corrected test for high value divisibility
+        // u32::MAX = 4294967295, which equals 1431655765 * 3 + 0
+        // So u32::MAX mod 3 = 0, which remains 0 (no centering needed)
+        assert_eq!(parts[0].coeffs[1], Zq::ZERO); // Remainder after division by 3
+        assert_eq!(parts[1].coeffs[1], Zq::new(1431655765)); // Quotient
+
+        // Check u32::MAX - 1 as well
+        // 4294967294 mod 3 = 1, which remains 1 (no centering needed since 1 <= half_base)
+        assert_eq!(parts[0].coeffs[2], Zq::MAX); // u32::MAX - 1 is the third coefficient
+        assert_eq!(parts[1].coeffs[2], Zq::new(1431655765)); // Should be same quotient
+    }
+
+    #[test]
+    fn test_decomposition_properties() {
+        // Test the algebraic property that all coefficients in first part should be small
+        let poly: Rq<8> = vec![
+            Zq::new(100),
+            Zq::new(200),
+            Zq::new(300),
+            Zq::new(400),
+            Zq::new(500),
+            Zq::new(600),
+            Zq::new(700),
+            Zq::new(800),
+        ]
+        .into();
+
+        for base in [2, 3, 4, 5, 8, 10, 16].iter() {
+            let parts = poly.decompose(Zq::new(*base), 2);
+            let half_base = Zq::new(*base).scale_by(Zq::TWO);
+
+            // Check that all coefficients in first part are properly "small"
+            for coeff in parts[0].coeffs.iter() {
+                // In centered representation, all coefficients should be <= half_base
+                let abs_coeff = if *coeff > Zq::new(u32::MAX / 2) {
+                    Zq::ZERO - *coeff // Handle negative values (represented as large positive ones)
+                } else {
+                    *coeff
+                };
+
+                assert!(
+                    abs_coeff <= half_base,
+                    "Base {}: First part coefficient {} exceeds half-base {}",
+                    base,
+                    coeff,
+                    half_base
+                );
+            }
+
+            // Verify reconstruction
+            let reconstructed = parts[0].clone() + parts[1].clone().scalar_mul(Zq::new(*base));
+            assert_eq!(reconstructed, poly, "Base {}: Reconstruction failed", base);
+        }
     }
 }

--- a/labrador/src/zq.rs
+++ b/labrador/src/zq.rs
@@ -17,6 +17,8 @@ impl Zq {
     pub const ZERO: Self = Self::new(0);
     /// Multiplicative identity
     pub const ONE: Self = Self::new(1);
+    /// Two
+    pub const TWO: Self = Self::new(2);
     /// Maximum element
     pub const MAX: Self = Self::new(u32::MAX);
 
@@ -32,6 +34,41 @@ impl Zq {
 
     pub const fn is_zero(&self) -> bool {
         self.value == 0
+    }
+
+    /// Returns the centered representative modulo the given bound
+    /// Result is guaranteed to be in (-bound/2, bound/2]
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bound` is zero.
+    pub(crate) fn centered_mod(&self, bound: Self) -> Self {
+        assert!(
+            bound != Zq::ZERO,
+            "cannot get centered representative modulo for zero bound"
+        );
+        let bounded_coeff = Self::new(self.value % bound.value);
+        let half_bound = bound.scale_by(Self::TWO);
+
+        if bounded_coeff > half_bound {
+            bounded_coeff - bound
+        } else {
+            bounded_coeff
+        }
+    }
+
+    /// Scales by other Zq.
+    ///
+    /// Effectively it is a floor division of internal values.
+    /// But for the ring of integers there is no defined division
+    /// operation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bound` is zero.
+    pub(crate) fn scale_by(&self, rhs: Self) -> Self {
+        assert!(rhs != Zq::ZERO, "cannot scale by zero");
+        Self::new(self.value / rhs.value)
     }
 }
 
@@ -49,6 +86,14 @@ macro_rules! impl_arithmetic {
         impl $assign_trait for Zq {
             fn $assign_method(&mut self, rhs: Self) {
                 self.value = self.value.$op(rhs.value);
+            }
+        }
+
+        impl $trait<Zq> for &Zq {
+            type Output = Zq;
+
+            fn $method(self, rhs: Zq) -> Self::Output {
+                Zq::new(self.value.$op(rhs.value))
             }
         }
     };
@@ -147,7 +192,7 @@ mod tests {
     fn test_subtraction_edge_cases() {
         let max = Zq::MAX;
         let one = Zq::ONE;
-        let two = Zq::new(2);
+        let two = Zq::TWO;
 
         assert_eq!((one - max).value, 2);
         assert_eq!((two - max).value, 3);
@@ -157,7 +202,7 @@ mod tests {
     #[test]
     fn test_multiplication_wrapping() {
         let a = Zq::new(1 << 31);
-        let two = Zq::new(2);
+        let two = Zq::TWO;
 
         // Multiplication wraps when exceeding u32 range
         assert_eq!((a * two).value, 0, "2^31 * 2 should wrap to 0");
@@ -200,7 +245,7 @@ mod tests {
 
         // Test negative equivalent value in multiplication
         let a = Zq::MAX; // Represents -1 in mod 2^32 arithmetic
-        let b = Zq::new(2);
+        let b = Zq::TWO;
         assert_eq!(
             (a * b).value,
             u32::MAX - 1,


### PR DESCRIPTION
This PR implements a two-layer hierarchical commitment structure that optimizes proof size in the LaBRADOR protocol. The implementation creates inner commitments for individual witnesses and outer commitments that summarize them, allowing material to be moved between proof iterations for more compact overall proof sizes.

Closes https://github.com/NethermindEth/condor-rs/issues/11

## Why

The LaBRADOR protocol's single-layer commitment scheme creates unnecessarily large proof sizes. This becomes a notable problem when you need to commit to multiple witness vectors at the same time.

## Summary of Changes

This PR implements a hierarchical commitment scheme for the LaBRADOR protocol, which creates a two-layer structure with inner and outer commitments. The key components include:

1. A new module `hierarchical_commitment.rs` that implements the full commitment structure
2. Documentation explaining the concept in `hierarchical_commitment.md`
3. Extensions to `Zq` arithmetic operations to support division and modulo
4. Addition of polynomial decomposition functionality to `Rq`

The hierarchical commitment structure optimizes proof size by allowing the prover to move material between proof iterations, resulting in more compact overall proofs.

## Code Changes

The main implementation is in the new `hierarchical_commitment.rs` file, which defines:

- `HierarchicalCommitment` - The main structure implementing the two-layer commitment scheme
- `DecompositionParameters` - Parameters for polynomial decomposition
- `HierarchicalProof` - Structure containing all information needed for verification

The implementation includes methods for committing to batches of witnesses and verifying proofs, with thorough error handling and validation.


## How the reviewer should approach it

1. Review the implementation of `HierarchicalCommitment` and its methods
2. Verify the polynomial decomposition logic in `decompose_polynomial` and `decompose_all_commitments`
3. Check the test cases for correctness, especially tamper commitments tests
4. Ensure the documentation accurately describes the hierarchical commitment concept

## Other useful info

The implementation includes:

1. A new `hierarchical_commitment.rs` module that implements the two-layer commitment structure
2. Extended `Zq` arithmetic operations to support division and modulo operations
3. Added polynomial decomposition functionality to the `Rq` type
4. Documentation in `hierarchical_commitment.md`

The hierarchical commitment scheme decomposes polynomial coefficients using a base-B representation with centered representatives to minimize coefficient magnitude. This approach allows for more efficient proof generation while maintaining security properties.


## Potential Issues

1. The decomposition process might be computationally intensive for large polynomials or many witnesses
2. The implementation assumes that the outer commitment scheme can handle the decomposed parts, which might not be true for all parameter configurations
3. The centered representative approach in decomposition could potentially introduce edge cases with certain moduli

