### PR TITLE
Refactor 2nd stage

### DIFF
--- a/labrador/src/core/jl.rs
+++ b/labrador/src/core/jl.rs
@@ -97,6 +97,7 @@ impl Projection {
 mod tests {
     use super::*;
     use crate::relation::witness::Witness;
+    use crate::ring::Norms;
     use crate::transcript::sponges::shake::ShakeSponge;
     use crate::transcript::LabradorTranscript;
     use rand::rng;
@@ -143,7 +144,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "skip-slow-tests"))]
     fn test_projection_average_value() {
-        use crate::relation::witness::Witness;
+        use crate::{relation::witness::Witness, ring::Norms};
 
         let (security_parameter, rank, multiplicity) = (128, 3, 1);
         let trials: u128 = 10000;

--- a/labrador/src/prover.rs
+++ b/labrador/src/prover.rs
@@ -22,7 +22,6 @@ use crate::relation::{
     witness::Witness,
 };
 use crate::ring::{rq_matrix::RqMatrix, rq_vector::RqVector, zq::Zq};
-
 use crate::transcript::{LabradorTranscript, Sponge};
 use thiserror::Error;
 
@@ -43,7 +42,7 @@ pub enum ProverError {
     DecompositionError(#[from] outer_commitments::DecompositionError),
 }
 
-/// Implements the steps executed by \(\mathcal{P}\) in the paper.
+/// Implements the steps executed by the prover \(\mathcal{P}\) in the paper.
 pub struct LabradorProver<'a> {
     /// System‑wide environment parameters like rank and multiplicity.
     params: &'a EnvironmentParameters,

--- a/labrador/src/relation/witness.rs
+++ b/labrador/src/relation/witness.rs
@@ -1,6 +1,6 @@
 use rand::rng;
 
-use crate::ring::{rq::Rq, rq_vector::RqVector, zq::Zq};
+use crate::ring::{rq::Rq, rq_vector::RqVector, zq::Zq, Norms};
 
 pub struct Witness {
     pub s: Vec<RqVector>,
@@ -35,7 +35,7 @@ impl Witness {
 #[cfg(test)]
 mod tests {
 
-    use crate::ring::{rq::Rq, rq_vector::RqVector, zq::Zq};
+    use crate::ring::{rq::Rq, rq_vector::RqVector, zq::Zq, Norms};
 
     use super::Witness;
 

--- a/labrador/src/ring/mod.rs
+++ b/labrador/src/ring/mod.rs
@@ -3,7 +3,7 @@ pub mod rq_matrix;
 pub mod rq_vector;
 pub mod zq;
 
-trait Norms {
+pub trait Norms {
     type NormType;
     fn l2_norm_squared(&self) -> Self::NormType;
 }

--- a/labrador/src/ring/mod.rs
+++ b/labrador/src/ring/mod.rs
@@ -2,3 +2,8 @@ pub mod rq;
 pub mod rq_matrix;
 pub mod rq_vector;
 pub mod zq;
+
+trait Norms {
+    type NormType;
+    fn l2_norm_squared(&self) -> Self::NormType;
+}

--- a/labrador/src/ring/zq.rs
+++ b/labrador/src/ring/zq.rs
@@ -211,9 +211,9 @@ pub fn add_assign_two_zq_vectors(first: &mut [Zq], second: Vec<Zq>) {
 impl Norms for [Zq] {
     type NormType = Zq;
 
+    #[allow(clippy::as_conversions)]
     fn l2_norm_squared(&self) -> Self::NormType {
-        self
-            .iter()
+        self.iter()
             .map(|coeff| {
                 coeff.centered_mod(Zq::new(Zq::Q as u32))
                     * coeff.centered_mod(Zq::new(Zq::Q as u32))
@@ -228,7 +228,15 @@ mod norm_tests {
 
     #[test]
     fn test_l2_norm() {
-        let zq_vector = vec![Zq::new(1), Zq::new(2), Zq::new(3), Zq::new(4), Zq::new(5), Zq::new(6), Zq::new(7)];
+        let zq_vector = [
+            Zq::new(1),
+            Zq::new(2),
+            Zq::new(3),
+            Zq::new(4),
+            Zq::new(5),
+            Zq::new(6),
+            Zq::new(7),
+        ];
         let res = zq_vector.l2_norm_squared();
 
         assert_eq!(res, Zq::new(140));
@@ -236,7 +244,15 @@ mod norm_tests {
 
     #[test]
     fn test_l2_norm_with_negative_values() {
-        let zq_vector = vec![Zq::new(1), Zq::new(2), Zq::new(3), -Zq::new(4), -Zq::new(5), -Zq::new(6), -Zq::new(7)];
+        let zq_vector = [
+            Zq::new(1),
+            Zq::new(2),
+            Zq::new(3),
+            -Zq::new(4),
+            -Zq::new(5),
+            -Zq::new(6),
+            -Zq::new(7),
+        ];
         let res = zq_vector.l2_norm_squared();
 
         assert_eq!(res, Zq::new(140));

--- a/labrador/src/verifier.rs
+++ b/labrador/src/verifier.rs
@@ -82,11 +82,13 @@ impl<'a> LabradorVerifier<'a> {
         let mut transcript = LabradorTranscript::new(S::default());
 
         transcript.absorb_u1(&proof.u1);
+
         let projections = transcript.generate_projections(
             env_params::SECURITY_PARAMETER,
             self.params.rank,
             self.params.multiplicity,
         );
+
         transcript.absorb_vector_p(&proof.vector_p);
         let size_of_psi = usize::div_ceil(env_params::SECURITY_PARAMETER, self.params.log_q);
         let size_of_omega = size_of_psi;

--- a/labrador/src/verifier.rs
+++ b/labrador/src/verifier.rs
@@ -6,6 +6,7 @@ use crate::commitments::common_instances::AjtaiInstances;
 use crate::commitments::outer_commitments::{self, DecompositionParameters};
 use crate::core::aggregate::{FunctionsAggregation, ZeroConstantFunctionsAggregation};
 use crate::core::inner_product;
+use crate::core::jl::Projection;
 use crate::relation::env_params;
 use crate::relation::{env_params::EnvironmentParameters, statement::Statement};
 use crate::ring::rq::Rq;
@@ -30,8 +31,12 @@ pub enum VerifierError {
         expected: Zq,
         computed: Zq,
     },
-    #[error("‖z‖² = {norm} exceeds allowed bound {allowed}")]
-    NormSumExceeded { norm: Zq, allowed: Zq },
+    #[error("Computed Norm: {norm} -- Maximum Bound {allowed}, Step: {step}")]
+    NormSumExceeded {
+        norm: u128,
+        allowed: u128,
+        step: String,
+    },
     #[error("A·z check failed: expected {expected:?}, computed {computed:?}")]
     AzError {
         computed: RqVector,
@@ -82,6 +87,74 @@ impl<'a> LabradorVerifier<'a> {
     ) -> Result<bool, VerifierError> {
         let mut transcript = LabradorTranscript::new(S::default());
 
+        let projections = self.check_vector_p_norm_bound(proof, &mut transcript)?;
+
+        // check b_0^{''(k)} ?= <omega^(k),p> + \sum(psi_l^(k) * b_0^{'(l)})
+        let (psi, omega) = self.check_b_double_prime_constant(proof, &mut transcript)?;
+
+        // 3. line 14: check norm_sum(z, t, g, h) <= (beta')^2
+        self.check_final_norm_sum(proof)?;
+
+        let vector_alpha = transcript.generate_rq_vector(self.params.constraint_k);
+        let vector_beta = transcript.generate_rq_vector(usize::div_ceil(
+            env_params::SECURITY_PARAMETER,
+            self.params.log_q,
+        ));
+        transcript.absorb_u2(&proof.u2);
+
+        // 4. line 15: check Az ?= c_1 * t_1 + ... + c_r * t_r
+        let challenges = self.check_az_amortization_correctness(proof, &mut transcript)?;
+
+        // 5. lne 16: check <z, z> ?= \sum(g_ij * c_i * c_j)
+        self.check_g_correctness(proof, &challenges)?;
+
+        // 6. line 17: check \sum(<\phi_i, z>c_i) ?= \sum(h_ij * c_i * c_j)
+        self.constant_aggregator.calculate_agg_phi_double_prime(
+            &self.st.phi_ct,
+            &projections.get_conjugated_projection_matrices(),
+            &psi,
+            &omega,
+        );
+        self.funcs_aggregator.calculate_aggr_phi(
+            &self.st.phi_constraint,
+            self.constant_aggregator.get_phi_double_prime(),
+            &vector_alpha,
+            &vector_beta,
+        );
+        self.check_h_correctness(proof, &challenges)?;
+
+        // 7. line 18: check \sum(a_ij * g_ij) + \sum(h_ii) - b ?= 0
+        self.constant_aggregator
+            .calculate_agg_a_double_prime(&psi, &self.st.a_ct);
+        self.funcs_aggregator.calculate_agg_a(
+            &self.st.a_constraint,
+            self.constant_aggregator.get_alpha_double_prime(),
+            &vector_alpha,
+            &vector_beta,
+        );
+
+        self.funcs_aggregator.calculate_aggr_b(
+            &self.st.b_constraint,
+            &proof.b_ct_aggr,
+            &vector_alpha,
+            &vector_beta,
+        );
+        self.check_aggregated_relation(proof)?;
+
+        // 8. line 19: u_1 ?= \sum(\sum(B_ik * t_i^(k))) + \sum(\sum(C_ijk * g_ij^(k)))
+        self.check_u1(proof)?;
+
+        // 9. line 20: u_2 ?= \sum(\sum(D_ijk * h_ij^(k)))
+        self.check_u2(proof)?;
+
+        Ok(true)
+    }
+
+    fn check_vector_p_norm_bound<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+        transcript: &mut LabradorTranscript<S>,
+    ) -> Result<Projection, VerifierError> {
         transcript.absorb_u1(&proof.u1);
 
         let projections = transcript.generate_projections(
@@ -89,25 +162,55 @@ impl<'a> LabradorVerifier<'a> {
             self.params.rank,
             self.params.multiplicity,
         );
-
         transcript.absorb_vector_p(&proof.vector_p);
+        if proof.vector_p.l2_norm_squared().to_u128()
+            > 128 * self.params.beta.to_u128() * self.params.beta.to_u128()
+        {
+            return Err(VerifierError::NormSumExceeded {
+                norm: proof.vector_p.l2_norm_squared().to_u128(),
+                allowed: 128 * self.params.beta.to_u128() * self.params.beta.to_u128(),
+                step: String::from("vector p norm check"),
+            });
+        }
+        Ok(projections)
+    }
+
+    fn check_b_double_prime_constant<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+        transcript: &mut LabradorTranscript<S>,
+    ) -> Result<(Vec<Vec<Zq>>, Vec<Vec<Zq>>), VerifierError> {
         let size_of_psi = usize::div_ceil(env_params::SECURITY_PARAMETER, self.params.log_q);
         let size_of_omega = size_of_psi;
         let psi = transcript.generate_vector_psi(size_of_psi, self.params.constraint_l);
         let omega = transcript.generate_vector_omega(size_of_omega, env_params::SECURITY_PARAMETER);
         transcript.absorb_vector_b_ct_aggr(&proof.b_ct_aggr);
-        let vector_alpha = transcript.generate_rq_vector(self.params.constraint_k);
-        let size_of_beta = size_of_psi;
-        let vector_beta = transcript.generate_rq_vector(size_of_beta);
-        transcript.absorb_u2(&proof.u2);
-        let challenges =
-            transcript.generate_challenges(env_params::OPERATOR_NORM, self.params.multiplicity);
 
-        // check b_0^{''(k)} ?= <omega^(k),p> + \sum(psi_l^(k) * b_0^{'(l)})
-        Self::check_b_0_aggr(self, proof, self.params, &psi, &omega)?;
+        for k in 0..self.params.kappa {
+            let b_0_poly = proof.b_ct_aggr.get_elements()[k].get_coefficients()[0];
+            let mut b_0: Zq = (0..self.params.constraint_l)
+                .map(|l| psi[k][l] * self.st.b_0_ct[l])
+                .sum();
 
-        // 3. line 14: check norm_sum(z, t, g, h) <= (beta')^2
+            let inner_omega_p =
+                inner_product::compute_linear_combination(&omega[k], &proof.vector_p);
+            b_0 += inner_omega_p;
+            if b_0 != b_0_poly {
+                return Err(VerifierError::B0Mismatch {
+                    index: k,
+                    expected: b_0_poly,
+                    computed: b_0,
+                });
+            }
+        }
 
+        Ok((psi, omega))
+    }
+
+    fn check_final_norm_sum<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+    ) -> Result<(), VerifierError> {
         // decompose z into z = z^(0) + z^(1) * b, only two parts.
         let z_ij = RqVector::decompose(&proof.z, self.params.b, 2);
         let t_ij: Vec<Vec<RqVector>> = proof
@@ -138,12 +241,21 @@ impl<'a> LabradorVerifier<'a> {
 
         if norm_sum > self.params.beta * self.params.beta {
             return Err(VerifierError::NormSumExceeded {
-                norm: norm_sum,
-                allowed: self.params.beta * self.params.beta,
+                norm: norm_sum.to_u128(),
+                allowed: (self.params.beta * self.params.beta).to_u128(),
+                step: String::from("Step 14 in verification"),
             });
         }
+        Ok(())
+    }
 
-        // 4. line 15: check Az ?= c_1 * t_1 + ... + c_r * t_r
+    fn check_az_amortization_correctness<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+        transcript: &mut LabradorTranscript<S>,
+    ) -> Result<RqVector, VerifierError> {
+        let challenges =
+            transcript.generate_challenges(env_params::OPERATOR_NORM, self.params.multiplicity);
         let az = self.crs.commitment_scheme_a.matrix() * &proof.z;
         let ct_sum = inner_product::compute_linear_combination(
             proof.t.get_elements(),
@@ -155,14 +267,19 @@ impl<'a> LabradorVerifier<'a> {
                 expected: ct_sum,
             });
         }
+        Ok(challenges)
+    }
 
-        // 5. lne 16: check <z, z> ?= \sum(g_ij * c_i * c_j)
-
+    fn check_g_correctness<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+        challenges: &RqVector,
+    ) -> Result<(), VerifierError> {
         let z_inner = inner_product::compute_linear_combination(
             proof.z.get_elements(),
             proof.z.get_elements(),
         );
-        let sum_gij_cij = Self::calculate_gh_ci_cj(&proof.g, &challenges, self.params.multiplicity);
+        let sum_gij_cij = Self::calculate_gh_ci_cj(&proof.g, challenges, self.params.multiplicity);
 
         if z_inner != sum_gij_cij {
             return Err(VerifierError::ZInnerError {
@@ -170,23 +287,17 @@ impl<'a> LabradorVerifier<'a> {
                 expected: sum_gij_cij,
             });
         }
+        Ok(())
+    }
 
-        // 6. line 17: check \sum(<\phi_i, z>c_i) ?= \sum(h_ij * c_i * c_j)
-        self.constant_aggregator.calculate_agg_phi_double_prime(
-            &self.st.phi_ct,
-            &projections.get_conjugated_projection_matrices(),
-            &psi,
-            &omega,
-        );
-        self.funcs_aggregator.calculate_aggr_phi(
-            &self.st.phi_constraint,
-            self.constant_aggregator.get_phi_double_prime(),
-            &vector_alpha,
-            &vector_beta,
-        );
+    fn check_h_correctness<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+        challenges: &RqVector,
+    ) -> Result<(), VerifierError> {
         let sum_phi_z_c =
-            Self::calculate_phi_z_c(self.funcs_aggregator.get_appr_phi(), &challenges, &proof.z);
-        let sum_hij_cij = Self::calculate_gh_ci_cj(&proof.h, &challenges, self.params.multiplicity);
+            Self::calculate_phi_z_c(self.funcs_aggregator.get_appr_phi(), challenges, &proof.z);
+        let sum_hij_cij = Self::calculate_gh_ci_cj(&proof.h, challenges, self.params.multiplicity);
 
         // Left side multiple by 2 because of when we calculate h_ij, we didn't apply the division (divided by 2)
         if &sum_phi_z_c * &Zq::TWO != sum_hij_cij {
@@ -195,25 +306,13 @@ impl<'a> LabradorVerifier<'a> {
                 expected: sum_hij_cij,
             });
         }
+        Ok(())
+    }
 
-        // 7. line 18: check \sum(a_ij * g_ij) + \sum(h_ii) - b ?= 0
-
-        self.constant_aggregator
-            .calculate_agg_a_double_prime(&psi, &self.st.a_ct);
-        self.funcs_aggregator.calculate_agg_a(
-            &self.st.a_constraint,
-            self.constant_aggregator.get_alpha_double_prime(),
-            &vector_alpha,
-            &vector_beta,
-        );
-
-        self.funcs_aggregator.calculate_aggr_b(
-            &self.st.b_constraint,
-            &proof.b_ct_aggr,
-            &vector_alpha,
-            &vector_beta,
-        );
-
+    fn check_aggregated_relation<S: Sponge>(
+        &self,
+        proof: &LabradorTranscript<S>,
+    ) -> Result<(), VerifierError> {
         if !Self::check_relation(
             self.funcs_aggregator.get_agg_a(),
             self.funcs_aggregator.get_aggr_b(),
@@ -222,9 +321,10 @@ impl<'a> LabradorVerifier<'a> {
         ) {
             return Err(VerifierError::RelationCheckFailed);
         }
+        Ok(())
+    }
 
-        // 8. line 19: u_1 ?= \sum(\sum(B_ik * t_i^(k))) + \sum(\sum(C_ijk * g_ij^(k)))
-
+    fn check_u1<S: Sponge>(&self, proof: &LabradorTranscript<S>) -> Result<(), VerifierError> {
         let u_1 = &proof.u1;
         let commitment_u1 = outer_commitments::compute_u1(
             self.crs,
@@ -240,8 +340,10 @@ impl<'a> LabradorVerifier<'a> {
                 expected: commitment_u1,
             });
         }
+        Ok(())
+    }
 
-        // 9. line 20: u_2 ?= \sum(\sum(D_ijk * h_ij^(k)))
+    fn check_u2<S: Sponge>(&self, proof: &LabradorTranscript<S>) -> Result<(), VerifierError> {
         let commitment_u2 = outer_commitments::compute_u2(
             self.crs,
             &proof.h,
@@ -254,8 +356,7 @@ impl<'a> LabradorVerifier<'a> {
                 expected: proof.u2.clone(),
             });
         }
-
-        Ok(true)
+        Ok(())
     }
 
     /// calculate the right hand side of line 16 or line 17, \sum(g_ij * c_i * c_j) or \sum(h_ij * c_i * c_j)
@@ -317,34 +418,6 @@ impl<'a> LabradorVerifier<'a> {
         let sum_a_primes_g2 = &sum_a_primes_g * &Zq::TWO;
 
         &sum_a_primes_g2 + &sum_h_ii == b_primes2
-    }
-
-    fn check_b_0_aggr<S: Sponge>(
-        &self,
-        proof: &LabradorTranscript<S>,
-        ep: &EnvironmentParameters,
-        psi: &[Vec<Zq>],
-        omega: &[Vec<Zq>],
-    ) -> Result<bool, VerifierError> {
-        for k in 0..ep.kappa {
-            let b_0_poly = proof.b_ct_aggr.get_elements()[k].get_coefficients()[0];
-            let mut b_0: Zq = (0..ep.constraint_l)
-                .map(|l| psi[k][l] * self.st.b_0_ct[l])
-                .sum();
-
-            let inner_omega_p =
-                inner_product::compute_linear_combination(&omega[k], &proof.vector_p);
-            b_0 += inner_omega_p;
-            if b_0 != b_0_poly {
-                return Err(VerifierError::B0Mismatch {
-                    index: k,
-                    expected: b_0_poly,
-                    computed: b_0,
-                });
-            }
-        }
-
-        Ok(true)
     }
 }
 

--- a/labrador/src/verifier.rs
+++ b/labrador/src/verifier.rs
@@ -12,6 +12,7 @@ use crate::ring::rq::Rq;
 use crate::ring::rq_matrix::RqMatrix;
 use crate::ring::rq_vector::RqVector;
 use crate::ring::zq::Zq;
+use crate::ring::Norms;
 use crate::transcript::{LabradorTranscript, Sponge};
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
# Summary
This PR completes the refactoring stage to enhance code efficiency and readability. The following changes have been made:
1. Introduced the `Norm` trait in the `ring` module to remove repetetive norm computation functionalities.
2. Split the `verifier()` function into smaller functions.
3. Added documentation for the prover and verifier functions.

# Next Steps
1. Refactor the `calculate_gh_ci_cj()` and `calculate_phi_z_c()` functions.
2. Replace `usize` data types with `u32` or `u64`.
3. Fix a bug in `check_final_norm_sum()`, which incorrectly compares the norm bound against beta instead of beta'. Currently, using beta' fails `test_verify` test case.