### PR TITLE
migrate to u64 and refactor

### DIFF
--- a/labrador/src/commitments/ajtai_commitment.rs
+++ b/labrador/src/commitments/ajtai_commitment.rs
@@ -1,6 +1,7 @@
 use crate::ring::rq_matrix::RqMatrix;
 use crate::ring::rq_vector::RqVector;
-use crate::ring::zq::Zq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 use crate::ring::Norms;
 use thiserror::Error;
 

--- a/labrador/src/commitments/outer_commitments.rs
+++ b/labrador/src/commitments/outer_commitments.rs
@@ -2,8 +2,11 @@ use thiserror::Error;
 
 use crate::{
     commitments::common_instances::AjtaiInstances,
-    ring::{rq_matrix::RqMatrix, rq_vector::RqVector, zq::Zq},
+    ring::{rq_matrix::RqMatrix, rq_vector::RqVector},
 };
+
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 
 use super::ajtai_commitment::AjtaiScheme;
 

--- a/labrador/src/core/aggregate.rs
+++ b/labrador/src/core/aggregate.rs
@@ -2,7 +2,8 @@ use crate::relation::env_params::EnvironmentParameters;
 use crate::ring::rq::Rq;
 use crate::ring::rq_matrix::RqMatrix;
 use crate::ring::rq_vector::RqVector;
-use crate::ring::zq::Zq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 
 use super::inner_product;
 

--- a/labrador/src/core/jl.rs
+++ b/labrador/src/core/jl.rs
@@ -1,6 +1,7 @@
 use crate::ring::rq_matrix::RqMatrix;
 use crate::ring::rq_vector::RqVector;
-use crate::ring::zq::Zq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 use crate::ring::{self, Norms};
 
 // LaBRADOR: Compact Proofs for R1CS from Module-SIS | Page 5 | Proving smallness section

--- a/labrador/src/prover.rs
+++ b/labrador/src/prover.rs
@@ -21,8 +21,8 @@ use crate::relation::{
     statement::Statement,
     witness::Witness,
 };
-use crate::ring::{rq_matrix::RqMatrix, rq_vector::RqVector};
 use crate::ring::zq::ZqLabrador;
+use crate::ring::{rq_matrix::RqMatrix, rq_vector::RqVector};
 type Zq = ZqLabrador;
 use crate::transcript::{LabradorTranscript, Sponge};
 use thiserror::Error;

--- a/labrador/src/prover.rs
+++ b/labrador/src/prover.rs
@@ -21,7 +21,9 @@ use crate::relation::{
     statement::Statement,
     witness::Witness,
 };
-use crate::ring::{rq_matrix::RqMatrix, rq_vector::RqVector, zq::Zq};
+use crate::ring::{rq_matrix::RqMatrix, rq_vector::RqVector};
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 use crate::transcript::{LabradorTranscript, Sponge};
 use thiserror::Error;
 

--- a/labrador/src/relation/env_params.rs
+++ b/labrador/src/relation/env_params.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::as_conversions)]
-use crate::ring::{rq::Rq};
+use crate::ring::rq::Rq;
 use crate::ring::zq::ZqLabrador;
 type Zq = ZqLabrador;
 

--- a/labrador/src/relation/env_params.rs
+++ b/labrador/src/relation/env_params.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::as_conversions)]
-use crate::ring::{rq::Rq, zq::Zq};
+use crate::ring::{rq::Rq};
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 
 /// Security Parameter
 pub const SECURITY_PARAMETER: usize = 128;
@@ -76,7 +78,7 @@ impl EnvironmentParameters {
         EnvironmentParameters {
             rank,
             multiplicity,
-            b: Zq::new(base_b as u32),
+            b: Zq::new(base_b as u64),
             b_1: base_b1,
             t_1: parts_t1,
             b_2: base_b2,

--- a/labrador/src/relation/statement.rs
+++ b/labrador/src/relation/statement.rs
@@ -3,7 +3,8 @@ use crate::relation::witness::Witness;
 use crate::ring::rq::Rq;
 use crate::ring::rq_matrix::RqMatrix;
 use crate::ring::rq_vector::RqVector;
-use crate::ring::zq::Zq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 
 use crate::core::inner_product;
 

--- a/labrador/src/relation/witness.rs
+++ b/labrador/src/relation/witness.rs
@@ -11,7 +11,7 @@ impl Witness {
         #[allow(clippy::as_conversions)]
         let std = ((bound_sq as f64) / ((rank * multiplicity * Rq::DEGREE) as f64)).sqrt();
         #[allow(clippy::as_conversions)]
-        let std = std as u32;
+        let std = std as u64;
         loop {
             let s: Vec<RqVector> = (0..multiplicity)
                 .map(|_| RqVector::random_with_bound(&mut rng(), rank, std))

--- a/labrador/src/ring/rq.rs
+++ b/labrador/src/ring/rq.rs
@@ -63,11 +63,11 @@ impl Rq {
     /// Decomposes a polynomial into base-B representation:
     /// p = p⁽⁰⁾ + p⁽¹⁾·B + p⁽²⁾·B² + ... + p⁽ᵗ⁻¹⁾·B^(t-1)
     /// Where each p⁽ⁱ⁾ has small coefficients, using centered representatives
-    pub fn decompose(&self, base: Zq, num_parts: usize) -> Vec<Rq> {
-        let mut result = vec![Rq::zero(); num_parts];
+    pub fn decompose(&self, base: Zq, num_parts: u64) -> Vec<Rq> {
+    let mut result = vec![Rq::zero(); num_parts as usize];
         self.coeffs.iter().enumerate().for_each(|(index, coeff)| {
             coeff
-                .decompose(base, num_parts)
+                .decompose(base, num_parts as u64)
                 .into_iter()
                 .zip(result.iter_mut())
                 .for_each(|(decomposed_coeff, decomposed_vec)| {
@@ -498,7 +498,7 @@ mod decomposition_tests {
     fn failure_test() {
         let poly1 =
             generate_rq_from_zq_vector(vec![-Zq::new(192), -Zq::new(0), -Zq::new(0), -Zq::new(0)]);
-        let decomposed = poly1.decompose(Zq::new(1802), 10);
+    let decomposed = poly1.decompose(Zq::new(1802), 10u64);
 
         let mut result = Rq::zero();
         let mut exponential_base = Zq::new(1);
@@ -514,7 +514,7 @@ mod decomposition_tests {
         // Test case 1: Base 2 decomposition
         let poly: Rq =
             generate_rq_from_zq_vector(vec![Zq::new(5), Zq::new(3), Zq::new(7), Zq::new(1)]);
-        let parts = poly.decompose(Zq::TWO, 4);
+    let parts = poly.decompose(Zq::TWO, 4u64);
 
         // Part 0: remainders mod 2 (no centering needed for base 2)
         assert_eq!(
@@ -558,7 +558,7 @@ mod decomposition_tests {
     fn test_decomposition_edge_cases() {
         // Test zero polynomial
         let zero_poly: Rq = generate_rq_from_zq_vector(vec![Zq::ZERO; 4]);
-        let parts = zero_poly.decompose(Zq::TWO, 2);
+    let parts = zero_poly.decompose(Zq::TWO, 2u64);
         assert!(
             // Check any polynomial is zero
             parts
@@ -570,7 +570,7 @@ mod decomposition_tests {
         // Test single part decomposition
         let simple_poly: Rq =
             generate_rq_from_zq_vector(vec![Zq::ONE, Zq::new(2), Zq::new(3), Zq::new(4)]);
-        let parts = simple_poly.decompose(Zq::TWO, 1);
+    let parts = simple_poly.decompose(Zq::TWO, 1u64);
         assert_eq!(parts.len(), 1, "Single part decomposition length incorrect");
     }
 
@@ -645,7 +645,7 @@ mod decomposition_tests {
             ],
         };
         let base = Zq::new(1802);
-        let decomposed = poly1.decompose(base, 2);
+    let decomposed = poly1.decompose(base, 2u64);
 
         // Verify reconstruction
         let reconstructed = &decomposed[0] + &(&decomposed[1] * &base);
@@ -725,7 +725,7 @@ mod decomposition_tests {
             ],
         };
         let base = Zq::new(1802);
-        let decomposed = poly1.decompose(base, 2);
+    let decomposed = poly1.decompose(base, 2u64);
 
         // Verify reconstruction
         for decomposed_poly in decomposed {

--- a/labrador/src/ring/rq.rs
+++ b/labrador/src/ring/rq.rs
@@ -64,10 +64,11 @@ impl Rq {
     /// p = p⁽⁰⁾ + p⁽¹⁾·B + p⁽²⁾·B² + ... + p⁽ᵗ⁻¹⁾·B^(t-1)
     /// Where each p⁽ⁱ⁾ has small coefficients, using centered representatives
     pub fn decompose(&self, base: Zq, num_parts: u64) -> Vec<Rq> {
-    let mut result = vec![Rq::zero(); num_parts as usize];
+        let mut result =
+            vec![Rq::zero(); usize::try_from(num_parts).expect("num_parts does not fit in usize")];
         self.coeffs.iter().enumerate().for_each(|(index, coeff)| {
             coeff
-                .decompose(base, num_parts as u64)
+                .decompose(base, num_parts)
                 .into_iter()
                 .zip(result.iter_mut())
                 .for_each(|(decomposed_coeff, decomposed_vec)| {
@@ -498,7 +499,7 @@ mod decomposition_tests {
     fn failure_test() {
         let poly1 =
             generate_rq_from_zq_vector(vec![-Zq::new(192), -Zq::new(0), -Zq::new(0), -Zq::new(0)]);
-    let decomposed = poly1.decompose(Zq::new(1802), 10u64);
+        let decomposed = poly1.decompose(Zq::new(1802), 10u64);
 
         let mut result = Rq::zero();
         let mut exponential_base = Zq::new(1);
@@ -514,7 +515,7 @@ mod decomposition_tests {
         // Test case 1: Base 2 decomposition
         let poly: Rq =
             generate_rq_from_zq_vector(vec![Zq::new(5), Zq::new(3), Zq::new(7), Zq::new(1)]);
-    let parts = poly.decompose(Zq::TWO, 4u64);
+        let parts = poly.decompose(Zq::TWO, 4u64);
 
         // Part 0: remainders mod 2 (no centering needed for base 2)
         assert_eq!(
@@ -558,7 +559,7 @@ mod decomposition_tests {
     fn test_decomposition_edge_cases() {
         // Test zero polynomial
         let zero_poly: Rq = generate_rq_from_zq_vector(vec![Zq::ZERO; 4]);
-    let parts = zero_poly.decompose(Zq::TWO, 2u64);
+        let parts = zero_poly.decompose(Zq::TWO, 2u64);
         assert!(
             // Check any polynomial is zero
             parts
@@ -570,7 +571,7 @@ mod decomposition_tests {
         // Test single part decomposition
         let simple_poly: Rq =
             generate_rq_from_zq_vector(vec![Zq::ONE, Zq::new(2), Zq::new(3), Zq::new(4)]);
-    let parts = simple_poly.decompose(Zq::TWO, 1u64);
+        let parts = simple_poly.decompose(Zq::TWO, 1u64);
         assert_eq!(parts.len(), 1, "Single part decomposition length incorrect");
     }
 
@@ -645,7 +646,7 @@ mod decomposition_tests {
             ],
         };
         let base = Zq::new(1802);
-    let decomposed = poly1.decompose(base, 2u64);
+        let decomposed = poly1.decompose(base, 2u64);
 
         // Verify reconstruction
         let reconstructed = &decomposed[0] + &(&decomposed[1] * &base);
@@ -725,7 +726,7 @@ mod decomposition_tests {
             ],
         };
         let base = Zq::new(1802);
-    let decomposed = poly1.decompose(base, 2u64);
+        let decomposed = poly1.decompose(base, 2u64);
 
         // Verify reconstruction
         for decomposed_poly in decomposed {

--- a/labrador/src/ring/rq.rs
+++ b/labrador/src/ring/rq.rs
@@ -1,6 +1,7 @@
 //! Polynomial ring **R = Z_q[X]/(X^d + 1)** with `d = 64` and `q = u32::MAX`.
 
-use crate::ring::zq::Zq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 use crate::ring::Norms;
 use core::ops::{Add, Mul, Sub};
 use rand::distr::{Distribution, Uniform};
@@ -47,7 +48,7 @@ impl Rq {
     }
 
     /// Random coefficients in `(-bound, bound)`.
-    pub fn random_with_bound<R: Rng + CryptoRng>(rng: &mut R, bound: u32) -> Self {
+    pub fn random_with_bound<R: Rng + CryptoRng>(rng: &mut R, bound: u64) -> Self {
         let uniform = Uniform::new_inclusive(Zq::ZERO, Zq::new(bound)).unwrap();
         let mut coeffs = [Zq::ZERO; Self::DEGREE];
         coeffs.iter_mut().for_each(|c| {

--- a/labrador/src/ring/rq.rs
+++ b/labrador/src/ring/rq.rs
@@ -578,82 +578,27 @@ mod decomposition_tests {
 
     #[test]
     fn test_decomposition_real_values() {
-        let poly1 = Rq {
-            coeffs: [
-                Zq::new(23071),
-                Zq::new(4294941461),
-                Zq::new(4084),
-                Zq::new(23413),
-                Zq::new(26902),
-                Zq::new(4294960817),
-                Zq::new(4294957829),
-                Zq::new(18248),
-                Zq::new(15293),
-                Zq::new(45978),
-                Zq::new(27197),
-                Zq::new(11233),
-                Zq::new(4294962536),
-                Zq::new(1196),
-                Zq::new(17083),
-                Zq::new(4294960822),
-                Zq::new(4294967103),
-                Zq::new(4294949429),
-                Zq::new(2926),
-                Zq::new(2742),
-                Zq::new(27552),
-                Zq::new(4294955871),
-                Zq::new(2917),
-                Zq::new(4294938904),
-                Zq::new(2288),
-                Zq::new(4294948781),
-                Zq::new(4294966588),
-                Zq::new(4294951307),
-                Zq::new(4294961210),
-                Zq::new(19355),
-                Zq::new(4294956913),
-                Zq::new(14940),
-                Zq::new(4294934068),
-                Zq::new(4294961161),
-                Zq::new(4294959017),
-                Zq::new(3339),
-                Zq::new(4294932967),
-                Zq::new(4294938251),
-                Zq::new(4294943006),
-                Zq::new(4294965167),
-                Zq::new(4294960800),
-                Zq::new(4161),
-                Zq::new(9213),
-                Zq::new(4294962556),
-                Zq::new(14299),
-                Zq::new(44418),
-                Zq::new(2438),
-                Zq::new(6583),
-                Zq::new(4294957783),
-                Zq::new(16),
-                Zq::new(4294941724),
-                Zq::new(4294966309),
-                Zq::new(4294966984),
-                Zq::new(4294956138),
-                Zq::new(1779),
-                Zq::new(29598),
-                Zq::new(16393),
-                Zq::new(728),
-                Zq::new(4294944371),
-                Zq::new(4294951792),
-                Zq::new(4294943824),
-                Zq::new(4294937618),
-                Zq::new(4294955208),
-                Zq::new(11235),
-            ],
-        };
+        // Generate realistic test data
+        let mut rng = rand::rng();
+        let mut coeffs = [Zq::ZERO; 64];
+
+        // Use realistic values - either small or near the modulus
+        for c in coeffs.iter_mut() {
+            // Example: random values in range [-1000, 1000]
+            let val = rng.random_range(0..2001);
+            *c = if val > 1000 {
+                -Zq::new(val - 1000)
+            } else {
+                Zq::new(val)
+            };
+        }
+
+        let poly1 = Rq { coeffs };
         let base = Zq::new(1802);
         let decomposed = poly1.decompose(base, 2u64);
 
-        // Verify reconstruction
         let reconstructed = &decomposed[0] + &(&decomposed[1] * &base);
-
-        assert_eq!(decomposed.len(), 2);
-        assert_eq!(reconstructed, poly1, "Base {base}: Reconstruction failed");
+        assert_eq!(reconstructed, poly1);
     }
 
     #[test]

--- a/labrador/src/ring/rq_matrix.rs
+++ b/labrador/src/ring/rq_matrix.rs
@@ -99,7 +99,7 @@ impl RqMatrix {
         let mut decomposed_vec = Vec::new();
         for ring_vector in self.elements() {
             for ring in ring_vector.elements() {
-                decomposed_vec.extend(ring.decompose(base, num_parts));
+                decomposed_vec.extend(ring.decompose(base, num_parts as u64));
             }
         }
         RqVector::new(decomposed_vec)

--- a/labrador/src/ring/rq_matrix.rs
+++ b/labrador/src/ring/rq_matrix.rs
@@ -6,7 +6,9 @@ use crate::{core::inner_product, ring::rq_vector::RqVector};
 use rand::{CryptoRng, Rng};
 use std::ops::Mul;
 
-use super::{rq::Rq, zq::Zq};
+use crate::ring::rq::Rq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 
 /// Matrix of polynomials in Rq
 #[derive(Debug, Clone)]

--- a/labrador/src/ring/rq_matrix.rs
+++ b/labrador/src/ring/rq_matrix.rs
@@ -99,7 +99,10 @@ impl RqMatrix {
         let mut decomposed_vec = Vec::new();
         for ring_vector in self.elements() {
             for ring in ring_vector.elements() {
-                decomposed_vec.extend(ring.decompose(base, num_parts as u64));
+                decomposed_vec.extend(ring.decompose(
+                    base,
+                    u64::try_from(num_parts).expect("num_parts does not fit in u64"),
+                ));
             }
         }
         RqVector::new(decomposed_vec)

--- a/labrador/src/ring/rq_vector.rs
+++ b/labrador/src/ring/rq_vector.rs
@@ -86,7 +86,7 @@ impl RqVector {
             .iter()
             .enumerate()
             .for_each(|(index, poly)| {
-                poly.decompose(b, parts as u64)
+                poly.decompose(b, u64::try_from(parts).expect("parts does not fit in u64"))
                     .into_iter()
                     .zip(result.iter_mut())
                     .for_each(|(decomposed_poly, decomposed_vec)| {

--- a/labrador/src/ring/rq_vector.rs
+++ b/labrador/src/ring/rq_vector.rs
@@ -86,7 +86,7 @@ impl RqVector {
             .iter()
             .enumerate()
             .for_each(|(index, poly)| {
-                poly.decompose(b, parts)
+                poly.decompose(b, parts as u64)
                     .into_iter()
                     .zip(result.iter_mut())
                     .for_each(|(decomposed_poly, decomposed_vec)| {

--- a/labrador/src/ring/rq_vector.rs
+++ b/labrador/src/ring/rq_vector.rs
@@ -1,6 +1,8 @@
 //! Dynamic vector of `Rq` elements.
 
-use crate::ring::zq::Zq;
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
+
 use crate::ring::{rq::Rq, Norms};
 use core::ops::Mul;
 use rand::{CryptoRng, Rng};
@@ -60,7 +62,7 @@ impl RqVector {
     }
 
     /// Random vector of given length with coefficients in `(-bound, bound)`.
-    pub fn random_with_bound<R: Rng + CryptoRng>(rng: &mut R, length: usize, bound: u32) -> Self {
+    pub fn random_with_bound<R: Rng + CryptoRng>(rng: &mut R, length: usize, bound: u64) -> Self {
         Self {
             elements: (0..length)
                 .map(|_| Rq::random_with_bound(rng, bound))
@@ -319,7 +321,7 @@ mod decomposition_tests {
     use super::*;
 
     fn default_base_and_parts() -> (Zq, usize) {
-        let base = Zq::new(2u32.pow(16));
+        let base = Zq::new(2u64.pow(16));
         let parts = 3; // 32 / 16 + (additional parts)
         (base, parts)
     }

--- a/labrador/src/ring/zq.rs
+++ b/labrador/src/ring/zq.rs
@@ -30,7 +30,7 @@ pub trait Mod: 'static + Copy + Clone + Send + Sync + PartialEq + Eq + PartialOr
     /// Optimized modular subtraction
     #[inline]
     fn sub_mod(a: u64, b: u64) -> u64 {
-        let diff = (a as u128 + Self::MODULUS as u128 - b as u128);
+        let diff = a as u128 + Self::MODULUS as u128 - b as u128;
         Self::reduce(diff)
     }
     
@@ -538,7 +538,7 @@ mod norm_tests {
 
 #[cfg(test)]
 mod decomposition_tests {
-    use crate::ring::{zq::Zq, Norms};
+    
     use super::*;
 
     type TestZq = ZqU32Max;

--- a/labrador/src/ring/zq.rs
+++ b/labrador/src/ring/zq.rs
@@ -4,55 +4,110 @@ use rand::distr::uniform::{Error, SampleBorrow, SampleUniform, UniformInt, Unifo
 use rand::prelude::*;
 use std::fmt;
 use std::iter::Sum;
+use std::marker::PhantomData;
 
-/// Element of the group **Z/(2^32 − 1)**.
-/// Uses native u32 operations with automatic modulo reduction through wrapping arithmetic.
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Default)]
-pub struct Zq {
-    /// Values in the range `0..u32::MAX−1`.
-    value: u32,
+/// Trait defining modular arithmetic parameters and operations
+pub trait Mod: 'static + Copy + Clone + Send + Sync + PartialEq + Eq + PartialOrd + Ord {
+    const MODULUS: u64;
+    const INV: u64; // multiplicative inverse for Montgomery reduction, etc.
+    const BITS: u32; // number of bits needed for this modulus
+    const ROOT_OF_UNITY: Option<u64> = None; // for NTT operations
+    const IS_PRIME: bool = true;
+    
+    /// Optimized modular reduction - can be overridden for specific moduli
+    #[inline]
+    fn reduce(value: u128) -> u64 {
+        (value % Self::MODULUS as u128) as u64
+    }
+    
+    /// Optimized modular addition
+    #[inline]
+    fn add_mod(a: u64, b: u64) -> u64 {
+        let sum = a as u128 + b as u128;
+        Self::reduce(sum)
+    }
+    
+    /// Optimized modular subtraction
+    #[inline]
+    fn sub_mod(a: u64, b: u64) -> u64 {
+        let diff = (a as u128 + Self::MODULUS as u128 - b as u128);
+        Self::reduce(diff)
+    }
+    
+    /// Optimized modular multiplication
+    #[inline]
+    fn mul_mod(a: u64, b: u64) -> u64 {
+        let prod = a as u128 * b as u128;
+        Self::reduce(prod)
+    }
+    
+    /// Modular negation
+    #[inline]
+    fn neg_mod(a: u64) -> u64 {
+        if a == 0 { 0 } else { Self::MODULUS - a }
+    }
 }
 
-impl Zq {
-    /// Modulus `q = 2^32 − 1`
-    #[allow(clippy::as_conversions)]
-    pub const Q: u32 = u32::MAX;
+/// Element of the group **Z/M::MODULUS** using trait-based modulus definition.
+/// Uses native u64 operations with automatic modulo reduction.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Default, Hash)]
+pub struct Zq<M: Mod> {
+    /// Values in the range `0..M::MODULUS`.
+    value: u64,
+    _phantom: PhantomData<M>,
+}
 
-    // ------- constants -------
-    pub const ZERO: Self = Self::new(0);
-    pub const ONE: Self = Self::new(1);
-    pub const TWO: Self = Self::new(2);
-    // -1 or Maximum possible value. Equals `q - 1` or ` 2^32 − 2`
-    pub const NEG_ONE: Self = Self::new(u32::MAX - 1);
-
-    /// Creates a new Zq element from a raw u32 value.
-    /// No explicit modulo needed as u32 automatically wraps
-    pub const fn new(value: u32) -> Self {
-        Self { value }
+impl<M: Mod> Zq<M> {
+    /// Creates a new Zq element from a raw u64 value.
+    /// Applies modulo M::MODULUS automatically
+    #[inline]
+    pub const fn new(value: u64) -> Self {
+        Self { 
+            value: if M::MODULUS == 0 { value } else { value % M::MODULUS },
+            _phantom: PhantomData,
+        }
+    }
+    
+    /// Creates a Zq element from a pre-reduced value (unsafe - no modulo check)
+    #[inline]
+    pub const fn from_raw(value: u64) -> Self {
+        Self {
+            value,
+            _phantom: PhantomData,
+        }
     }
 
+    // Constants - now using the trait's MODULUS
+    pub const ZERO: Self = Self::from_raw(0);
+    pub const ONE: Self = Self::from_raw(1);
+    pub const TWO: Self = Self::from_raw(2);
+    // -1 or Maximum possible value. Equals `M::MODULUS - 1`
+    pub const NEG_ONE: Self = Self::from_raw(M::MODULUS - 1);
+
+    #[inline]
     pub fn to_u128(&self) -> u128 {
         u128::from(self.value)
     }
 
-    pub fn get_value(&self) -> u32 {
+    #[inline]
+    pub fn get_value(&self) -> u64 {
         self.value
     }
 
+    #[inline]
     pub const fn is_zero(&self) -> bool {
         self.value == 0
     }
 
-    /// Returns `1` iff the element is in `(q-1/2, q)`
-    #[allow(clippy::as_conversions)]
+    /// Returns `true` iff the element is in `(M::MODULUS-1/2, M::MODULUS)`
+    #[inline]
     pub fn is_larger_than_half(&self) -> bool {
-        self.value > (Self::Q - 1) / 2
+        self.value > (M::MODULUS - 1) / 2
     }
 
-    /// Centered representative in `(-q/2, q/2]`.
-    #[allow(clippy::as_conversions)]
+    /// Centered representative in `(-M::MODULUS/2, M::MODULUS/2]`.
     pub(crate) fn centered_mod(&self) -> i128 {
-        let bound = Self::Q as i128;
+        let bound = M::MODULUS as i128;
         let value = self.value as i128;
 
         if value > (bound - 1) / 2 {
@@ -62,24 +117,25 @@ impl Zq {
         }
     }
 
-    /// Floor division by another `Zq` value (*not* a field inverse!, just dividing the values).
-    pub(crate) fn div_floor_by(&self, rhs: u32) -> Self {
+    /// Floor division by another value (*not* a field inverse!, just dividing the values).
+    pub(crate) fn div_floor_by(&self, rhs: u64) -> Self {
         assert_ne!(rhs, 0, "division by zero");
         Self::new(self.value / rhs)
     }
 
     /// Decompose the element to #num_parts number of parts,
     /// where each part's infinity norm is less than or equal to bound/2
-    pub(crate) fn decompose(&self, bound: Self, num_parts: u64) -> Vec<Zq> {
+    pub(crate) fn decompose(&self, bound: Self, num_parts: u64) -> Vec<Self> {
         assert!(bound >= Self::TWO, "base must be ≥ 2");
         assert_ne!(num_parts, 0, "num_parts cannot be zero");
 
         let mut parts =
             vec![Self::ZERO; usize::try_from(num_parts).expect("num_parts does not fit in usize")];
         let half_bound = bound.div_floor_by(2);
-        let mut abs_self = match self.is_larger_than_half() {
-            true => -(*self),
-            false => *self,
+        let mut abs_self = if self.is_larger_than_half() {
+            -(*self)
+        } else {
+            *self
         };
 
         for part in &mut parts {
@@ -87,9 +143,10 @@ impl Zq {
             if remainder > half_bound {
                 remainder -= bound;
             }
-            *part = match self.is_larger_than_half() {
-                true => -remainder,
-                false => remainder,
+            *part = if self.is_larger_than_half() {
+                -remainder
+            } else {
+                remainder
             };
             abs_self = Self::new((abs_self - remainder).value / bound.value);
             if abs_self == Self::ZERO {
@@ -99,136 +156,177 @@ impl Zq {
         parts
     }
 
-    #[allow(clippy::as_conversions)]
-    fn add_op(self, rhs: Zq) -> Zq {
-        let sum = (self.value as u64 + rhs.value as u64) % Zq::Q as u64;
-        Zq::new(sum as u32)
-    }
+    // Remove the internal arithmetic methods since we'll use the trait methods directly
+}
 
-    #[allow(clippy::as_conversions)]
-    fn sub_op(self, rhs: Zq) -> Zq {
-        let sub = (self.value as u64 + Zq::Q as u64 - rhs.value as u64) % Zq::Q as u64;
-        Zq::new(sub as u32)
-    }
+// Arithmetic implementations using the trait methods
+impl<M: Mod> Add for Zq<M> {
+    type Output = Self;
 
-    #[allow(clippy::as_conversions)]
-    fn mul_op(self, b: Zq) -> Zq {
-        let prod = (self.value as u64 * b.value as u64) % Zq::Q as u64;
-        Zq::new(prod as u32)
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::from_raw(M::add_mod(self.value, rhs.value))
     }
 }
 
-// Macro to generate arithmetic trait implementations
-macro_rules! impl_arithmetic {
-    ($trait:ident, $assign_trait:ident, $method:ident, $assign_method:ident, $op:ident) => {
-        impl $trait for Zq {
-            type Output = Self;
+impl<M: Mod> Sub for Zq<M> {
+    type Output = Self;
 
-            fn $method(self, rhs: Self) -> Self::Output {
-                self.$op(rhs)
-            }
-        }
-
-        impl $assign_trait for Zq {
-            fn $assign_method(&mut self, rhs: Self) {
-                *self = self.$op(rhs);
-            }
-        }
-
-        impl $trait<Zq> for &Zq {
-            type Output = Zq;
-
-            fn $method(self, rhs: Zq) -> Self::Output {
-                self.$op(rhs)
-            }
-        }
-
-        impl $trait<&Zq> for &Zq {
-            type Output = Zq;
-
-            fn $method(self, rhs: &Zq) -> Self::Output {
-                self.$op(*rhs)
-            }
-        }
-    };
-}
-
-impl_arithmetic!(Add, AddAssign, add, add_assign, add_op);
-impl_arithmetic!(Sub, SubAssign, sub, sub_assign, sub_op);
-impl_arithmetic!(Mul, MulAssign, mul, mul_assign, mul_op);
-
-// Implement the Neg trait for Zq.
-impl Neg for Zq {
-    type Output = Zq;
-
-    /// Returns the additive inverse of the field element.
-    ///
-    /// Wrap around (q - a) mod q.
-    fn neg(self) -> Zq {
-        // If the value is zero, its inverse is itself.
-        if self.value == 0 {
-            self
-        } else {
-            #[allow(clippy::as_conversions)]
-            Zq::new(Zq::Q - self.get_value())
-        }
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::from_raw(M::sub_mod(self.value, rhs.value))
     }
 }
 
-impl fmt::Display for Zq {
+impl<M: Mod> Mul for Zq<M> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::from_raw(M::mul_mod(self.value, rhs.value))
+    }
+}
+
+impl<M: Mod> Neg for Zq<M> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        Self::from_raw(M::neg_mod(self.value))
+    }
+}
+
+// Assignment operators
+impl<M: Mod> AddAssign for Zq<M> {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<M: Mod> SubAssign for Zq<M> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<M: Mod> MulAssign for Zq<M> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+// Reference implementations
+impl<M: Mod> Add<Zq<M>> for &Zq<M> {
+    type Output = Zq<M>;
+    
+    #[inline]
+    fn add(self, rhs: Zq<M>) -> Self::Output {
+        *self + rhs
+    }
+}
+
+impl<M: Mod> Add<&Zq<M>> for &Zq<M> {
+    type Output = Zq<M>;
+    
+    #[inline]
+    fn add(self, rhs: &Zq<M>) -> Self::Output {
+        *self + *rhs
+    }
+}
+
+impl<M: Mod> Sub<Zq<M>> for &Zq<M> {
+    type Output = Zq<M>;
+    
+    #[inline]
+    fn sub(self, rhs: Zq<M>) -> Self::Output {
+        *self - rhs
+    }
+}
+
+impl<M: Mod> Sub<&Zq<M>> for &Zq<M> {
+    type Output = Zq<M>;
+    
+    #[inline]
+    fn sub(self, rhs: &Zq<M>) -> Self::Output {
+        *self - *rhs
+    }
+}
+
+impl<M: Mod> Mul<Zq<M>> for &Zq<M> {
+    type Output = Zq<M>;
+    
+    #[inline]
+    fn mul(self, rhs: Zq<M>) -> Self::Output {
+        *self * rhs
+    }
+}
+
+impl<M: Mod> Mul<&Zq<M>> for &Zq<M> {
+    type Output = Zq<M>;
+    
+    #[inline]
+    fn mul(self, rhs: &Zq<M>) -> Self::Output {
+        *self * *rhs
+    }
+}
+
+impl<M: Mod> fmt::Display for Zq<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Shows value with modulus for clarity
-        write!(f, "{} (mod {})", self.value, Zq::Q)
+        write!(f, "{} (mod {})", self.value, M::MODULUS)
     }
 }
 
+// Random sampling
 #[derive(Clone, Copy, Debug)]
-pub struct UniformZq(UniformInt<u32>);
+pub struct UniformZq<M: Mod>(UniformInt<u64>, PhantomData<M>);
 
-impl UniformSampler for UniformZq {
-    type X = Zq;
+impl<M: Mod> UniformSampler for UniformZq<M> {
+    type X = Zq<M>;
 
     fn new<B1, B2>(low: B1, high: B2) -> Result<Self, Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
     {
-        UniformInt::<u32>::new(low.borrow().value, high.borrow().value).map(UniformZq)
+        UniformInt::<u64>::new(low.borrow().value, high.borrow().value)
+            .map(|sampler| UniformZq(sampler, PhantomData))
     }
+    
     fn new_inclusive<B1, B2>(low: B1, high: B2) -> Result<Self, Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
     {
-        UniformInt::<u32>::new_inclusive(low.borrow().value, high.borrow().value).map(UniformZq)
+        UniformInt::<u64>::new_inclusive(low.borrow().value, high.borrow().value)
+            .map(|sampler| UniformZq(sampler, PhantomData))
     }
+    
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
         Self::X::new(self.0.sample(rng))
     }
 }
 
-impl SampleUniform for Zq {
-    type Sampler = UniformZq;
+impl<M: Mod> SampleUniform for Zq<M> {
+    type Sampler = UniformZq<M>;
 }
 
-impl Sum for Zq {
-    // Accumulate using the addition operator
-    fn sum<I>(iter: I) -> Self
-    where
-        I: Iterator<Item = Zq>,
-    {
-        iter.fold(Zq::ZERO, |acc, x| acc + x)
+impl<M: Mod> Sum for Zq<M> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |a, b| a + b)
     }
 }
 
 /// Adds `rhs` into `lhs` component‑wise.
-pub fn add_assign_two_zq_vectors(lhs: &mut [Zq], rhs: Vec<Zq>) {
+pub fn add_assign_two_zq_vectors<M: Mod>(lhs: &mut [Zq<M>], rhs: Vec<Zq<M>>) {
     debug_assert_eq!(lhs.len(), rhs.len(), "vector length mismatch");
     lhs.iter_mut().zip(rhs).for_each(|(l, r)| *l += r);
 }
 
 // Implement l2 and infinity norms for a slice of Zq elements
-impl Norms for [Zq] {
+impl<M: Mod> Norms for [Zq<M>] {
     type NormType = u128;
 
     #[allow(clippy::as_conversions)]
@@ -248,35 +346,79 @@ impl Norms for [Zq] {
     }
 }
 
+// Define specific moduli for different use cases
+
+/// The original u32::MAX modulus from your implementation
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct U32MaxMod;
+impl Mod for U32MaxMod {
+    const MODULUS: u64 = u64::MAX;
+    const INV: u64 = 0; // Not used for this modulus
+    const BITS: u32 = 32;
+    const IS_PRIME: bool = false; // 2^32 - 1 is not prime
+}
+
+/// Standard LaBRADOR modulus (CRYSTALS-Dilithium compatible)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LabradorMod;
+impl Mod for LabradorMod {
+    const MODULUS: u64 = 8380417; // 2^23 - 2^13 + 1
+    const INV: u64 = 58728449; // Precomputed inverse
+    const BITS: u32 = 23;
+    const ROOT_OF_UNITY: Option<u64> = Some(1753);
+}
+
+/// Falcon-512 single signature modulus (41 bits, but truncated to fit u32)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Falcon512Mod;
+impl Mod for Falcon512Mod {
+    const MODULUS: u64 = (1u64 << 31) - 1;
+    const INV: u64 = 0;
+    const BITS: u32 = 31;
+    const IS_PRIME: bool = true; // 2^31 - 1 is a Mersenne prime
+}
+
+// Type aliases for convenience and backward compatibility
+pub type ZqU32Max = Zq<U32MaxMod>;
+pub type ZqLabrador = Zq<LabradorMod>;
+pub type ZqFalcon512 = Zq<Falcon512Mod>;
+
+// For your existing code, you can use ZqU32Max as a drop-in replacement
+// Or create a simple type alias:
+// pub type Zq = ZqU32Max;
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // Use the original modulus for backward compatibility
+    type TestZq = ZqU32Max;
+
     #[test]
     fn test_to_u128() {
-        let a = Zq::new(10);
+        let a = TestZq::new(10);
         let b = a.to_u128();
         assert_eq!(b, 10u128);
     }
 
     #[test]
     fn test_is_zero() {
-        let a = Zq::new(0);
-        let b = Zq::new(10);
+        let a = TestZq::new(0);
+        let b = TestZq::new(10);
         assert!(a.is_zero());
         assert!(!b.is_zero());
     }
 
     #[test]
     fn test_get_value() {
-        let a = Zq::new(1000);
-        assert_eq!(a.get_value(), 1000u32);
+        let a = TestZq::new(1000);
+        assert_eq!(a.get_value(), 1000u64);
     }
 
     #[test]
     fn test_basic_arithmetic() {
-        let a = Zq::new(5);
-        let b = Zq::new(3);
+        let a = TestZq::new(5);
+        let b = TestZq::new(3);
 
         // Addition
         assert_eq!((a + b).value, 8, "5 + 3 should be 8");
@@ -288,37 +430,29 @@ mod tests {
 
     #[test]
     fn test_wrapping_arithmetic() {
-        let a = Zq::NEG_ONE;
-        let b = Zq::ONE;
+        let a = TestZq::NEG_ONE;
+        let b = TestZq::ONE;
 
-        assert_eq!((a + b).value, 0, "u32::MAX + 1 should wrap to 0");
-        assert_eq!((b - a).value, 2, "1 - u32::MAX should wrap to 2 (mod 2^32)");
+        assert_eq!((a + b).value, 0, "u32::MAX-1 + 1 should wrap to 0");
+        assert_eq!((b - a).value, 2, "1 - (u32::MAX-1) should wrap to 2");
     }
 
     #[test]
-    fn test_subtraction_edge_cases() {
-        let max = Zq::NEG_ONE;
-        let one = Zq::ONE;
-        let two = Zq::TWO;
+    fn test_different_moduli() {
+        let labrador_a = ZqLabrador::new(5);
+        let labrador_b = ZqLabrador::new(3);
+        let result = labrador_a + labrador_b;
+        assert_eq!(result.get_value(), 8);
 
-        assert_eq!((one - max).value, 2);
-        assert_eq!((two - max).value, 3);
-        assert_eq!((max - max).value, 0);
-    }
-
-    #[test]
-    fn test_multiplication_wrapping() {
-        let a = Zq::new(1 << 31);
-        let two = Zq::TWO;
-
-        // Multiplication wraps when exceeding u32 range
-        assert_eq!((a * two).value, 1, "2^31 * 2 should wrap to 1");
+        // Test that we can't accidentally mix different moduli
+        // This would cause a compile-time error:
+        // let mixed = labrador_a + TestZq::new(3); // Compile error!
     }
 
     #[test]
     fn test_assignment_operators() {
-        let mut a = Zq::new(5);
-        let b = Zq::new(3);
+        let mut a = TestZq::new(5);
+        let b = TestZq::new(3);
 
         a += b;
         assert_eq!(a.value, 8, "5 += 3 should be 8");
@@ -331,178 +465,89 @@ mod tests {
     }
 
     #[test]
-    fn test_conversion_from_u32() {
-        let a: Zq = Zq::new(5);
-        assert_eq!(a.value, 5, "Conversion from u32 should preserve value");
-    }
+    fn test_neg() {
+        let a = TestZq::new(100);
+        let b = TestZq::ZERO;
+        let neg_a: TestZq = -a;
+        let neg_b: TestZq = -b;
 
-    #[test]
-    fn test_negative_arithmetic() {
-        let small = Zq::new(3);
-        let large = Zq::new(5);
-
-        // Test underflow handling (3 - 5 in u32 terms)
-        let result = small - large;
-        assert_eq!(result.value, u32::MAX - 2, "3 - 5 should wrap to 2^32 - 2");
-
-        // Test compound negative operations
-        let mut x = Zq::new(10);
-        x -= Zq::new(15);
-        assert_eq!(x.value, u32::MAX - 5, "10 -= 15 should wrap to 2^32 - 5");
-
-        // Test negative equivalent value in multiplication
-        let a = Zq::NEG_ONE; // Represents -1 in mod 2^32 arithmetic
-        let b = Zq::TWO;
-        assert_eq!(
-            (a * b).value,
-            u32::MAX - 2,
-            "(-1) * 2 should be -2 ≡ 2^32 - 2"
-        );
+        assert_eq!(neg_a + a, TestZq::ZERO);
+        assert_eq!(neg_b, TestZq::ZERO);
     }
 
     #[test]
     fn test_display_implementation() {
-        let a = Zq::new(5);
-        let max = Zq::NEG_ONE;
-        assert_eq!(format!("{a}"), format!("5 (mod {})", Zq::Q));
-        assert_eq!(format!("{max}"), format!("4294967294 (mod {})", Zq::Q));
-    }
-
-    #[test]
-    fn test_maximum_element() {
-        dbg!(Zq::NEG_ONE);
-        dbg!(Zq::ZERO);
-        dbg!(Zq::ONE);
-        dbg!(Zq::ZERO - Zq::ONE);
-        assert_eq!(Zq::NEG_ONE, Zq::ZERO - Zq::ONE);
-    }
-
-    #[test]
-    fn test_ord() {
-        let a = Zq::new(100);
-        let b = Zq::new(200);
-        let c = Zq::new(100);
-        let d = Zq::new(400);
-
-        let res_1 = a.cmp(&b);
-        let res_2 = a.cmp(&c);
-        let res_3 = d.cmp(&b);
-        assert!(res_1.is_lt());
-        assert!(res_2.is_eq());
-        assert!(res_3.is_gt());
-        assert_eq!(a, c);
-        assert!(a < b);
-        assert!(d > b);
-    }
-
-    #[test]
-    fn test_neg() {
-        let a = Zq::new(100);
-        let b = Zq::ZERO;
-        let neg_a: Zq = -a;
-        let neg_b: Zq = -b;
-
-        assert_eq!(neg_a + a, Zq::ZERO);
-        assert_eq!(neg_b, Zq::ZERO);
-    }
-
-    #[test]
-    fn test_centered_mod() {
-        let a = -Zq::new(1);
-        assert_eq!(-1, a.centered_mod());
-
-        let a = Zq::new(4294967103);
-        assert_eq!(a, -Zq::new(192));
-        assert_eq!(-192, a.centered_mod());
+        let a = TestZq::new(5);
+        let max = TestZq::NEG_ONE;
+        assert_eq!(format!("{a}"), "5 (mod 4294967295)");
+        assert_eq!(format!("{max}"), "4294967294 (mod 4294967295)");
     }
 }
 
 #[cfg(test)]
 mod norm_tests {
     use super::*;
+    
+    type TestZq = ZqU32Max;
 
     #[test]
     fn test_l2_norm() {
         let zq_vector = [
-            Zq::new(1),
-            Zq::new(2),
-            Zq::new(3),
-            Zq::new(4),
-            Zq::new(5),
-            Zq::new(6),
-            Zq::new(7),
+            TestZq::new(1),
+            TestZq::new(2),
+            TestZq::new(3),
+            TestZq::new(4),
+            TestZq::new(5),
+            TestZq::new(6),
+            TestZq::new(7),
         ];
         let res = zq_vector.l2_norm_squared();
-
         assert_eq!(res, 140);
     }
 
     #[test]
     fn test_l2_norm_with_negative_values() {
         let zq_vector = [
-            Zq::new(1),
-            Zq::new(2),
-            Zq::new(3),
-            -Zq::new(4),
-            -Zq::new(5),
-            -Zq::new(6),
-            -Zq::new(7),
+            TestZq::new(1),
+            TestZq::new(2),
+            TestZq::new(3),
+            -TestZq::new(4),
+            -TestZq::new(5),
+            -TestZq::new(6),
+            -TestZq::new(7),
         ];
         let res = zq_vector.l2_norm_squared();
-
         assert_eq!(res, 140);
     }
 
     #[test]
     fn test_linf_norm() {
         let zq_vector = [
-            Zq::new(1),
-            Zq::new(200),
-            Zq::new(300),
-            Zq::new(40),
-            -Zq::new(5),
-            -Zq::new(6),
-            -Zq::new(700000),
+            TestZq::new(1),
+            TestZq::new(200),
+            TestZq::new(300),
+            TestZq::new(40),
+            -TestZq::new(5),
+            -TestZq::new(6),
+            -TestZq::new(700000),
         ];
         let res = zq_vector.linf_norm();
         assert_eq!(res, 700000);
-
-        let zq_vector = [
-            Zq::new(1000000),
-            Zq::new(200),
-            Zq::new(300),
-            Zq::new(40),
-            -Zq::new(5),
-            -Zq::new(6),
-            -Zq::new(999999),
-        ];
-        let res = zq_vector.linf_norm();
-        assert_eq!(res, 1000000);
-
-        let zq_vector = [
-            Zq::new(1),
-            Zq::new(2),
-            Zq::new(3),
-            -Zq::new(4),
-            Zq::new(0),
-            -Zq::new(3),
-            -Zq::new(2),
-            -Zq::new(1),
-        ];
-        let res = zq_vector.linf_norm();
-        assert_eq!(res, 4);
     }
 }
 
 #[cfg(test)]
 mod decomposition_tests {
     use crate::ring::{zq::Zq, Norms};
+    use super::*;
+
+    type TestZq = ZqU32Max;
 
     #[test]
     fn test_zq_decomposition() {
-        let (base, parts) = (Zq::new(12), 10);
-        let pos_zq = Zq::new(29);
-        let neg_zq = -Zq::new(29);
+        let (base, parts) = (TestZq::new(12), 10);
+        let pos_zq = TestZq::new(29);
+        let neg_zq = -TestZq::new(29);
 
         let pos_decomposed = pos_zq.decompose(base, parts);
         let neg_decomposed = neg_zq.decompose(base, parts);
@@ -510,72 +555,47 @@ mod decomposition_tests {
         assert_eq!(
             pos_decomposed,
             vec![
-                Zq::new(5),
-                Zq::new(2),
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO
+                TestZq::new(5),
+                TestZq::new(2),
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO
             ]
         );
         assert_eq!(
             neg_decomposed,
             vec![
-                -Zq::new(5),
-                -Zq::new(2),
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO,
-                Zq::ZERO
+                -TestZq::new(5),
+                -TestZq::new(2),
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO,
+                TestZq::ZERO
             ]
         );
     }
 
     #[test]
-    fn test_zq_recompositoin() {
-        let (base, parts) = (Zq::new(1802), 10);
-        let pos_zq = -Zq::new(16200);
+    fn test_zq_recomposition() {
+        let (base, parts) = (TestZq::new(1802), 10);
+        let pos_zq = -TestZq::new(16200);
 
         let pos_decomposed = pos_zq.decompose(base, parts);
-        let mut exponensial_base = Zq::new(1);
-        let mut result = Zq::new(0);
+        let mut exponential_base = TestZq::new(1);
+        let mut result = TestZq::new(0);
         for decomposed_part in pos_decomposed {
-            result += decomposed_part * exponensial_base;
-            exponensial_base *= base;
+            result += decomposed_part * exponential_base;
+            exponential_base *= base;
         }
         assert_eq!(result, pos_zq)
-    }
-
-    #[test]
-    fn test_zq_recompositoin_positive() {
-        let (base, parts) = (Zq::new(1802), 10);
-        let pos_zq = Zq::new(23071);
-
-        let pos_decomposed = pos_zq.decompose(base, parts);
-        let mut exponensial_base = Zq::new(1);
-        let mut result = Zq::new(0);
-        for decomposed_part in pos_decomposed {
-            result += decomposed_part * exponensial_base;
-            exponensial_base *= base;
-        }
-        assert_eq!(result, pos_zq)
-    }
-
-    #[test]
-    fn test_linf_norm() {
-        let (base, parts) = (Zq::new(1802), 10);
-        let pos_zq = Zq::new(16200);
-
-        let pos_decomposed = pos_zq.decompose(base, parts);
-        dbg!(&pos_decomposed);
-        assert!(pos_decomposed.linf_norm() <= 901);
     }
 }

--- a/labrador/src/ring/zq.rs
+++ b/labrador/src/ring/zq.rs
@@ -74,7 +74,8 @@ impl Zq {
         assert!(bound >= Self::TWO, "base must be ≥ 2");
         assert_ne!(num_parts, 0, "num_parts cannot be zero");
 
-    let mut parts = vec![Self::ZERO; num_parts as usize];
+        let mut parts =
+            vec![Self::ZERO; usize::try_from(num_parts).expect("num_parts does not fit in usize")];
         let half_bound = bound.div_floor_by(2);
         let mut abs_self = match self.is_larger_than_half() {
             true => -(*self),

--- a/labrador/src/ring/zq.rs
+++ b/labrador/src/ring/zq.rs
@@ -70,11 +70,11 @@ impl Zq {
 
     /// Decompose the element to #num_parts number of parts,
     /// where each part's infinity norm is less than or equal to bound/2
-    pub(crate) fn decompose(&self, bound: Self, num_parts: usize) -> Vec<Zq> {
+    pub(crate) fn decompose(&self, bound: Self, num_parts: u64) -> Vec<Zq> {
         assert!(bound >= Self::TWO, "base must be ≥ 2");
         assert_ne!(num_parts, 0, "num_parts cannot be zero");
 
-        let mut parts = vec![Self::ZERO; num_parts];
+    let mut parts = vec![Self::ZERO; num_parts as usize];
         let half_bound = bound.div_floor_by(2);
         let mut abs_self = match self.is_larger_than_half() {
             true => -(*self),

--- a/labrador/src/transcript/mod.rs
+++ b/labrador/src/transcript/mod.rs
@@ -1,9 +1,9 @@
 pub mod sponges;
+use crate::ring::zq::ZqLabrador;
 use crate::{
     core::jl::Projection,
     ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector},
 };
-use crate::ring::zq::ZqLabrador;
 type Zq = ZqLabrador;
 pub use sponges::Sponge;
 

--- a/labrador/src/transcript/mod.rs
+++ b/labrador/src/transcript/mod.rs
@@ -1,8 +1,10 @@
 pub mod sponges;
 use crate::{
     core::jl::Projection,
-    ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector, zq::Zq},
+    ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector},
 };
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 pub use sponges::Sponge;
 
 pub struct LabradorTranscript<S: Sponge> {
@@ -94,9 +96,9 @@ impl<S: Sponge> LabradorTranscript<S> {
                         let coeffs = chunk
                             .iter()
                             .map(|elem| {
-                                if elem.get_value() < 2_u32.pow(30) {
+                                if elem.get_value() < 2_u64.pow(30) {
                                     Zq::NEG_ONE
-                                } else if elem.get_value() < 2_u32.pow(31) {
+                                } else if elem.get_value() < 2_u64.pow(31) {
                                     Zq::ONE
                                 } else {
                                     Zq::ZERO

--- a/labrador/src/transcript/mod.rs
+++ b/labrador/src/transcript/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector},
 };
 type Zq = ZqLabrador;
+use crate::ring::zq::{LabradorMod, Mod};
 pub use sponges::Sponge;
 
 pub struct LabradorTranscript<S: Sponge> {
@@ -83,9 +84,12 @@ impl<S: Sponge> LabradorTranscript<S> {
         rank: usize,
         multiplicity: usize,
     ) -> Projection {
-        // r vectors, each of length 256 * nD
         let row_size = 2 * security_parameter;
         let col_size = rank * Rq::DEGREE;
+
+        // Precompute thresholds
+        let quarter = LabradorMod::MODULUS / 4;
+        let three_quarters = 3 * quarter;
 
         let matrices = (0..multiplicity)
             .map(|_| {
@@ -96,12 +100,13 @@ impl<S: Sponge> LabradorTranscript<S> {
                         let coeffs = chunk
                             .iter()
                             .map(|elem| {
-                                if elem.get_value() < 2_u64.pow(30) {
+                                let val = elem.get_value();
+                                if val < quarter {
                                     Zq::NEG_ONE
-                                } else if elem.get_value() < 2_u64.pow(31) {
-                                    Zq::ONE
-                                } else {
+                                } else if val < three_quarters {
                                     Zq::ZERO
+                                } else {
+                                    Zq::ONE
                                 }
                             })
                             .collect();

--- a/labrador/src/transcript/sponges/mod.rs
+++ b/labrador/src/transcript/sponges/mod.rs
@@ -1,4 +1,4 @@
-use crate::ring::{rq::Rq};
+use crate::ring::rq::Rq;
 use crate::ring::zq::ZqLabrador;
 type Zq = ZqLabrador;
 

--- a/labrador/src/transcript/sponges/mod.rs
+++ b/labrador/src/transcript/sponges/mod.rs
@@ -1,4 +1,6 @@
-use crate::ring::{rq::Rq, zq::Zq};
+use crate::ring::{rq::Rq};
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 
 pub trait Sponge: Default {
     fn absorb_zq(&mut self, input: &[Zq]);

--- a/labrador/src/transcript/sponges/shake/mod.rs
+++ b/labrador/src/transcript/sponges/shake/mod.rs
@@ -3,7 +3,7 @@ use sha3::{
     Shake256,
 };
 
-use crate::ring::{rq::Rq};
+use crate::ring::rq::Rq;
 use crate::ring::zq::ZqLabrador;
 type Zq = ZqLabrador;
 use crate::transcript::Sponge;

--- a/labrador/src/transcript/sponges/shake/mod.rs
+++ b/labrador/src/transcript/sponges/shake/mod.rs
@@ -3,7 +3,9 @@ use sha3::{
     Shake256,
 };
 
-use crate::ring::{rq::Rq, zq::Zq};
+use crate::ring::{rq::Rq};
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 use crate::transcript::Sponge;
 
 #[derive(Default)]
@@ -61,7 +63,7 @@ impl Sponge for ShakeSponge {
         let zq_values: Vec<Zq> = output_buffer
             .chunks_exact(4)
             .map(|chunk| {
-                u32::from_le_bytes(chunk.try_into().expect("Could not convert 4 u8 to one u32"))
+                u64::from_le_bytes(chunk.try_into().expect("Could not convert 4 u8 to one u64"))
             })
             .map(Zq::new)
             .collect();
@@ -78,7 +80,7 @@ impl Sponge for ShakeSponge {
         let zq_values: Vec<Zq> = output_buffer
             .chunks_exact(4)
             .map(|chunk| {
-                u32::from_le_bytes(chunk.try_into().expect("Could not convert 4 u8 to one u32"))
+                u64::from_le_bytes(chunk.try_into().expect("Could not convert 4 u8 to one u64"))
             })
             .map(Zq::new)
             .collect();

--- a/labrador/src/transcript/sponges/shake/mod.rs
+++ b/labrador/src/transcript/sponges/shake/mod.rs
@@ -15,20 +15,20 @@ pub struct ShakeSponge {
 
 impl Sponge for ShakeSponge {
     fn absorb_zq(&mut self, input: &[Zq]) {
-        // Convert Rq ector to u8
+        // Convert Zq vector to u8 - using little-endian for consistency
         let mut u8_version_input: Vec<u8> = Vec::new();
         for coeff in input {
-            u8_version_input.extend_from_slice(&coeff.get_value().to_be_bytes());
+            u8_version_input.extend_from_slice(&coeff.get_value().to_le_bytes());
         }
         self.hasher.update(&u8_version_input);
     }
 
     fn absorb_rq(&mut self, input: &[Rq]) {
-        // Convert Rq ector to u8
+        // Convert Rq vector to u8 - using little-endian for consistency
         let mut u8_version_input: Vec<u8> = Vec::new();
         for rq in input {
             for coeff in rq.coeffs() {
-                u8_version_input.extend_from_slice(&coeff.get_value().to_be_bytes());
+                u8_version_input.extend_from_slice(&coeff.get_value().to_le_bytes());
             }
         }
         self.hasher.update(&u8_version_input);
@@ -57,15 +57,16 @@ impl Sponge for ShakeSponge {
 
     fn squeeze_zq(&mut self, output_length: usize) -> Vec<Zq> {
         let mut reader = self.hasher.clone().finalize_xof();
-        let mut output_buffer = vec![u8::default(); output_length * 4];
+        // We need 8 bytes for a u64
+        let mut output_buffer = vec![u8::default(); output_length * 8];
         reader.read(&mut output_buffer);
 
         let zq_values: Vec<Zq> = output_buffer
-            .chunks_exact(4)
+            .chunks_exact(8)
             .map(|chunk| {
-                u64::from_le_bytes(chunk.try_into().expect("Could not convert 4 u8 to one u64"))
+                u64::from_le_bytes(chunk.try_into().expect("Could not convert 8 u8 to one u64"))
             })
-            .map(Zq::new)
+            .map(Zq::new) // This applies modulo automatically
             .collect();
 
         self.absorb_zq(&zq_values);
@@ -74,13 +75,14 @@ impl Sponge for ShakeSponge {
 
     fn squeeze_rq(&mut self, output_length: usize) -> Vec<Rq> {
         let mut reader = self.hasher.clone().finalize_xof();
-        let mut output_buffer = vec![u8::default(); output_length * Rq::DEGREE * 4];
+        // IMPORTANT: We need 8 bytes for a u64, not 4!
+        let mut output_buffer = vec![u8::default(); output_length * Rq::DEGREE * 8];
         reader.read(&mut output_buffer);
 
         let zq_values: Vec<Zq> = output_buffer
-            .chunks_exact(4)
+            .chunks_exact(8) // Changed from 4 to 8
             .map(|chunk| {
-                u64::from_le_bytes(chunk.try_into().expect("Could not convert 4 u8 to one u64"))
+                u64::from_le_bytes(chunk.try_into().expect("Could not convert 8 u8 to one u64"))
             })
             .map(Zq::new)
             .collect();

--- a/labrador/src/verifier.rs
+++ b/labrador/src/verifier.rs
@@ -28,7 +28,9 @@ use crate::core::aggregate::{FunctionsAggregation, ZeroConstantFunctionsAggregat
 use crate::core::{inner_product, jl::Projection};
 use crate::relation::env_params;
 use crate::relation::{env_params::EnvironmentParameters, statement::Statement};
-use crate::ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector, zq::Zq, Norms};
+use crate::ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector, Norms};
+use crate::ring::zq::ZqLabrador;
+type Zq = ZqLabrador;
 use crate::transcript::{LabradorTranscript, Sponge};
 use thiserror::Error;
 

--- a/labrador/src/verifier.rs
+++ b/labrador/src/verifier.rs
@@ -28,8 +28,8 @@ use crate::core::aggregate::{FunctionsAggregation, ZeroConstantFunctionsAggregat
 use crate::core::{inner_product, jl::Projection};
 use crate::relation::env_params;
 use crate::relation::{env_params::EnvironmentParameters, statement::Statement};
-use crate::ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector, Norms};
 use crate::ring::zq::ZqLabrador;
+use crate::ring::{rq::Rq, rq_matrix::RqMatrix, rq_vector::RqVector, Norms};
 type Zq = ZqLabrador;
 use crate::transcript::{LabradorTranscript, Sponge};
 use thiserror::Error;

--- a/labrador/src/verifier.rs
+++ b/labrador/src/verifier.rs
@@ -142,17 +142,29 @@ impl<'a> LabradorVerifier<'a> {
         proof: &LabradorTranscript<S>,
         transcript: &mut LabradorTranscript<S>,
     ) -> Result<(Vec<Vec<Zq>>, Vec<Vec<Zq>>), VerifierError> {
-    let size_of_psi = u64::try_from(env_params::SECURITY_PARAMETER).unwrap().div_ceil(self.params.log_q as u64) as usize;
-    let size_of_omega = size_of_psi;
+        let size_of_psi = {
+            let sec_param = u64::try_from(env_params::SECURITY_PARAMETER)
+                .expect("SECURITY_PARAMETER does not fit in u64");
+            let log_q = u64::try_from(self.params.log_q).expect("log_q does not fit in u64");
+            usize::try_from(sec_param.div_ceil(log_q))
+                .expect("div_ceil result does not fit in usize")
+        };
+        let size_of_omega = size_of_psi;
         let psi = transcript.generate_vector_psi(size_of_psi, self.params.constraint_l);
         let omega = transcript.generate_vector_omega(size_of_omega, env_params::SECURITY_PARAMETER);
         transcript.absorb_vector_b_ct_aggr(&proof.b_ct_aggr);
 
-        for k in 0..self.params.kappa as u64 {
-            let k_usize = k as usize;
+        let kappa_u64 = u64::try_from(self.params.kappa).expect("kappa does not fit in u64");
+        for k in 0..kappa_u64 {
+            let k_usize = usize::try_from(k).expect("k does not fit in usize");
             let b_0_poly = proof.b_ct_aggr.elements()[k_usize].coeffs()[0];
-            let mut b_0: Zq = (0..self.params.constraint_l as u64)
-                .map(|l| psi[k_usize][l as usize] * self.st.b_0_ct[l as usize])
+            let constraint_l_u64 =
+                u64::try_from(self.params.constraint_l).expect("constraint_l does not fit in u64");
+            let mut b_0: Zq = (0..constraint_l_u64)
+                .map(|l| {
+                    let l_usize = usize::try_from(l).expect("l does not fit in usize");
+                    psi[k_usize][l_usize] * self.st.b_0_ct[l_usize]
+                })
                 .sum();
 
             let inner_omega_p =
@@ -183,7 +195,7 @@ impl<'a> LabradorVerifier<'a> {
         proof: &LabradorTranscript<S>,
     ) -> Result<(), VerifierError> {
         // decompose z into z = z^(0) + z^(1) * b, only two parts.
-    let z_ij = proof.z.decompose(self.params.b, 2);
+        let z_ij = proof.z.decompose(self.params.b, 2);
         let t_ij: Vec<Vec<RqVector>> = proof
             .t
             .elements()
@@ -229,7 +241,7 @@ impl<'a> LabradorVerifier<'a> {
         transcript: &mut LabradorTranscript<S>,
     ) -> Result<RqVector, VerifierError> {
         let challenges =
-            transcript.generate_challenges(env_params::OPERATOR_NORM, self.params.multiplicity as usize);
+            transcript.generate_challenges(env_params::OPERATOR_NORM, self.params.multiplicity);
         let az = self.crs.commitment_scheme_a.matrix() * &proof.z;
         let ct_sum =
             inner_product::compute_linear_combination(proof.t.elements(), challenges.elements());
@@ -254,7 +266,7 @@ impl<'a> LabradorVerifier<'a> {
     ) -> Result<(), VerifierError> {
         let z_inner =
             inner_product::compute_linear_combination(proof.z.elements(), proof.z.elements());
-    let sum_gij_cij = Self::calculate_gh_ci_cj(&proof.g, challenges, self.params.multiplicity);
+        let sum_gij_cij = Self::calculate_gh_ci_cj(&proof.g, challenges, self.params.multiplicity);
 
         if z_inner != sum_gij_cij {
             return Err(VerifierError::ZInnerError {
@@ -277,7 +289,7 @@ impl<'a> LabradorVerifier<'a> {
     ) -> Result<(), VerifierError> {
         let sum_phi_z_c =
             Self::calculate_phi_z_c(self.funcs_aggregator.get_appr_phi(), challenges, &proof.z);
-    let sum_hij_cij = Self::calculate_gh_ci_cj(&proof.h, challenges, self.params.multiplicity);
+        let sum_hij_cij = Self::calculate_gh_ci_cj(&proof.h, challenges, self.params.multiplicity);
 
         // Left side multiple by 2 because of when we calculate h_ij, we didn't apply the division (divided by 2)
         if &sum_phi_z_c * &Zq::TWO != sum_hij_cij {
@@ -297,7 +309,7 @@ impl<'a> LabradorVerifier<'a> {
         &self,
         proof: &LabradorTranscript<S>,
     ) -> Result<(), VerifierError> {
-    let r = self.funcs_aggregator.get_agg_a().elements().len();
+        let r = self.funcs_aggregator.get_agg_a().elements().len();
 
         let mut sum_a_primes_g = Rq::zero();
         // walk only over the stored half: i ≤ j
@@ -371,8 +383,7 @@ impl<'a> LabradorVerifier<'a> {
         let mut result = Rq::zero();
         for i in 0..r {
             let c_i = &c_elements[i];
-            for j in 0..r {
-                let c_j = &c_elements[j];
+            for (j, c_j) in c_elements.iter().enumerate().take(r) {
                 // x_ij[i,j] * c_i * c_j
                 let term = &(&(x_ij.get_cell(i, j) * c_i) * c_j);
                 result = &result + term;
@@ -386,7 +397,8 @@ impl<'a> LabradorVerifier<'a> {
         phi.iter()
             .zip(c.elements())
             .map(|(phi_i, c_i)| {
-                let inner_prod = inner_product::compute_linear_combination(phi_i.elements(), z.elements());
+                let inner_prod =
+                    inner_product::compute_linear_combination(phi_i.elements(), z.elements());
                 &inner_prod * c_i
             })
             .fold(Rq::zero(), |acc, term| &acc + &term)


### PR DESCRIPTION
https://github.com/NethermindEth/condor-rs/issues/85
https://github.com/NethermindEth/condor-rs/issues/70

Refactor the calculate_gh_ci_cj() and calculate_phi_z_c() functions.
Replace usize data types with u32 or u64.

The last item in the issue, "Fix a bug in check_final_norm_sum(), which incorrectly compares the norm bound against beta instead of beta'. Currently, using beta' fails test_verify test case." has already been addressed in refactor 2